### PR TITLE
Updates README.md: neatly aligns "Rank" union type

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ type Planet = {
   habitable: boolean
 }
 
-type Rank
-  = 'captain'
+type Rank =
+  | 'captain'
   | 'first mate'
   | 'officer'
   | 'ensign'


### PR DESCRIPTION
TypeScript allows an optional leading `|` in union types, which you can use to align the string literal types in the `Rank` more neatly.