### PR TITLE
Add key to error message of value's runtype.

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -79,6 +79,7 @@ const testValues: { value: always, passes: RuntypeName[] }[] = [
   { value: { Boolean: true }, passes: ['Partial'] },
   { value: { Boolean: true, foo: undefined }, passes: ['Partial'] },
   { value: { Boolean: true, foo: 'hello' }, passes: ['Partial'] },
+  { value: { Boolean: true, foo: 5 }, passes: [] },
   { value: (x: number, y: string) => x + y.length, passes: ['Function'] },
   { value: { name: 'Jimmy', likes: [{ name: 'Peter', likes: [] }] }, passes: ['Person'] },
   { value: { a: '1', b: '2' }, passes: ['Dictionary'] },
@@ -86,6 +87,7 @@ const testValues: { value: always, passes: RuntypeName[] }[] = [
   { value: { 1: '1', 2: '2' }, passes: ['Dictionary', 'NumberDictionary'] },
   { value: { a: [], b: [true, false] }, passes: ['DictionaryOfArrays'] },
   { value: new Foo(), passes: [] },
+  { value: { Boolean: true, Number: '5' }, passes: ['Partial'] }
 ]
 
 for (const { value, passes } of testValues) {

--- a/src/types/optional.ts
+++ b/src/types/optional.ts
@@ -18,8 +18,13 @@ export function Optional<O extends { [_: string]: Rt }>(fields: O) {
 
     // tslint:disable-next-line:forin
     for (const key in fields)
-      if (hasKey(key, x))
-        Union(fields[key], Undefined).check(x[key])
+      if (hasKey(key, x)) {
+        try {
+          Union(fields[key], Undefined).check(x[key])
+        } catch ({ message }) {
+          throw validationError(`In key ${key}: ${message}`)
+        }
+      }
 
     return x as Partial<O>
   }, { tag: 'optional', fields })

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -16,9 +16,13 @@ export function Record<O extends { [_: string]: Rt }>(fields: O) {
 
     // tslint:disable-next-line:forin
     for (const key in fields) {
-      if (hasKey(key, x))
-        fields[key].check(x[key])
-      else
+      if (hasKey(key, x)) {
+        try {
+          fields[key].check(x[key])
+        } catch ({ message }) {
+          throw validationError(`In key ${key}: ${message}`)
+        }
+      } else
         throw validationError(`Missing property ${key}`)
     }
 


### PR DESCRIPTION
This PR adds additional documentation to the type checking errors in `Record` and `Optional` types. If one of the key checks fails, the `Record` will add `In key ${key}:` to the beginning of the string, indicating which of the keys has the problem.