### PR TITLE
Incremental checking + parallel pattern matching

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -46,41 +46,41 @@ class SomeOtherClass {
 }
 
 const runtypes = {
-  Always,
-  Never,
-  Undefined,
-  Null,
-  Empty: Record({}),
-  Void,
-  Boolean,
-  true: Literal(true),
-  false: Literal(false),
-  Number,
-  3: Literal(3),
-  42: Literal(42),
-  String,
-  'hello world': Literal('hello world'),
-  boolArray: Array(Boolean),
-  boolTuple,
-  record1,
+  // Always,
+  // Never,
+  // Undefined,
+  // Null,
+  // Empty: Record({}),
+  // Void,
+  // Boolean,
+  // true: Literal(true),
+  // false: Literal(false),
+  // Number,
+  // 3: Literal(3),
+  // 42: Literal(42),
+  // String,
+  // 'hello world': Literal('hello world'),
+  // boolArray: Array(Boolean),
+  // boolTuple,
+  // record1,
   union1,
   Partial: Partial({ foo: String }).And(Record({ Boolean })),
-  Function,
-  Person,
-  MoreThanThree: Number.withConstraint(n => n > 3),
-  MoreThanThreeWithMessage: Number.withConstraint(n => n > 3 || `${n} is not greater than 3`),
-  ArrayNumber: Array(Number),
-  CustomArray: Array(Number).withConstraint(x => x.length > 3, { tag: 'lenght', min: 3 }),
-  CustomArrayWithMessage: Array(Number).withConstraint(
-    x => x.length > 3 || `Length array is not greater 3`,
-    { tag: 'lenght', min: 3 },
-  ),
-  Dictionary: Dictionary(String),
-  NumberDictionary: Dictionary(String, 'number'),
-  DictionaryOfArrays: Dictionary(Array(Boolean)),
-  InstanceOfSomeClass: InstanceOf(SomeClass),
-  InstanceOfSomeOtherClass: InstanceOf(SomeOtherClass),
-  DictionaryOfArraysOfSomeClass: Dictionary(Array(InstanceOf(SomeClass))),
+  // Function,
+  // Person,
+  // MoreThanThree: Number.withConstraint(n => n > 3),
+  // MoreThanThreeWithMessage: Number.withConstraint(n => n > 3 || `${n} is not greater than 3`),
+  // ArrayNumber: Array(Number),
+  // CustomArray: Array(Number).withConstraint(x => x.length > 3, { tag: 'lenght', min: 3 }),
+  // CustomArrayWithMessage: Array(Number).withConstraint(
+  //   x => x.length > 3 || `Length array is not greater 3`,
+  //   { tag: 'lenght', min: 3 },
+  // ),
+  // Dictionary: Dictionary(String),
+  // NumberDictionary: Dictionary(String, 'number'),
+  // DictionaryOfArrays: Dictionary(Array(Boolean)),
+  // InstanceOfSomeClass: InstanceOf(SomeClass),
+  // InstanceOfSomeOtherClass: InstanceOf(SomeOtherClass),
+  // DictionaryOfArraysOfSomeClass: Dictionary(Array(InstanceOf(SomeClass))),
 };
 
 type RuntypeName = keyof typeof runtypes;
@@ -92,31 +92,31 @@ class Foo {
 } // Should not be recognized as a Dictionary
 
 const testValues: { value: always; passes: RuntypeName[] }[] = [
-  { value: undefined, passes: ['Undefined', 'Void'] },
-  { value: null, passes: ['Null', 'Void'] },
-  { value: true, passes: ['Boolean', 'true'] },
-  { value: false, passes: ['Boolean', 'false'] },
-  { value: 3, passes: ['Number', '3', 'union1'] },
-  { value: 42, passes: ['Number', '42', 'MoreThanThree', 'MoreThanThreeWithMessage'] },
-  { value: 'hello world', passes: ['String', 'hello world', 'union1'] },
-  { value: [true, false, true], passes: ['boolArray', 'boolTuple', 'union1'] },
-  { value: { Boolean: true, Number: 3 }, passes: ['record1', 'union1', 'Partial'] },
+  // { value: undefined, passes: ['Undefined', 'Void'] },
+  // { value: null, passes: ['Null', 'Void'] },
+  // { value: true, passes: ['Boolean', 'true'] },
+  // { value: false, passes: ['Boolean', 'false'] },
+  // { value: 3, passes: ['Number', '3', 'union1'] },
+  // { value: 42, passes: ['Number', '42', 'MoreThanThree', 'MoreThanThreeWithMessage'] },
+  // { value: 'hello world', passes: ['String', 'hello world', 'union1'] },
+  // { value: [true, false, true], passes: ['boolArray', 'boolTuple', 'union1'] },
+  // { value: { Boolean: true, Number: 3 }, passes: ['record1', 'union1', 'Partial'] },
   { value: { Boolean: true }, passes: ['Partial'] },
-  { value: { Boolean: true, foo: undefined }, passes: ['Partial'] },
-  { value: { Boolean: true, foo: 'hello' }, passes: ['Partial'] },
-  { value: { Boolean: true, foo: 5 }, passes: [] },
-  { value: (x: number, y: string) => x + y.length, passes: ['Function'] },
-  { value: { name: 'Jimmy', likes: [{ name: 'Peter', likes: [] }] }, passes: ['Person'] },
-  { value: { a: '1', b: '2' }, passes: ['Dictionary'] },
-  { value: ['1', '2'], passes: ['NumberDictionary'] },
-  { value: { 1: '1', 2: '2' }, passes: ['Dictionary', 'NumberDictionary'] },
-  { value: { a: [], b: [true, false] }, passes: ['DictionaryOfArrays'] },
-  { value: new Foo(), passes: [] },
-  { value: [1, 2, 4], passes: ['ArrayNumber'] },
-  { value: { Boolean: true, Number: '5' }, passes: ['Partial'] },
-  { value: [1, 2, 3, 4], passes: ['ArrayNumber', 'CustomArray', 'CustomArrayWithMessage'] },
-  { value: new SomeClass(42), passes: ['InstanceOfSomeClass'] },
-  { value: { xxx: [new SomeClass(55)] }, passes: ['DictionaryOfArraysOfSomeClass'] },
+  // { value: { Boolean: true, foo: undefined }, passes: ['Partial'] },
+  // { value: { Boolean: true, foo: 'hello' }, passes: ['Partial'] },
+  // { value: { Boolean: true, foo: 5 }, passes: [] },
+  // { value: (x: number, y: string) => x + y.length, passes: ['Function'] },
+  // { value: { name: 'Jimmy', likes: [{ name: 'Peter', likes: [] }] }, passes: ['Person'] },
+  // { value: { a: '1', b: '2' }, passes: ['Dictionary'] },
+  // { value: ['1', '2'], passes: ['NumberDictionary'] },
+  // { value: { 1: '1', 2: '2' }, passes: ['Dictionary', 'NumberDictionary'] },
+  // { value: { a: [], b: [true, false] }, passes: ['DictionaryOfArrays'] },
+  // { value: new Foo(), passes: [] },
+  // { value: [1, 2, 4], passes: ['ArrayNumber'] },
+  // { value: { Boolean: true, Number: '5' }, passes: ['Partial'] },
+  // { value: [1, 2, 3, 4], passes: ['ArrayNumber', 'CustomArray', 'CustomArrayWithMessage'] },
+  // { value: new SomeClass(42), passes: ['InstanceOfSomeClass'] },
+  // { value: { xxx: [new SomeClass(55)] }, passes: ['DictionaryOfArraysOfSomeClass'] },
 ];
 
 for (const { value, passes } of testValues) {
@@ -140,154 +140,154 @@ for (const { value, passes } of testValues) {
   });
 }
 
-describe('contracts', () => {
-  it('0 args', () => {
-    const f = () => 3;
-    expect(Contract(Number).enforce(f)()).toBe(3);
-    try {
-      Contract(String).enforce(f as any)();
-      fail('contract was violated but no exception was thrown');
-    } catch (e) {
-      /* success */
-    }
-  });
+// describe('contracts', () => {
+//   it('0 args', () => {
+//     const f = () => 3;
+//     expect(Contract(Number).enforce(f)()).toBe(3);
+//     try {
+//       Contract(String).enforce(f as any)();
+//       fail('contract was violated but no exception was thrown');
+//     } catch (e) {
+//       /* success */
+//     }
+//   });
 
-  it('1 arg', () => {
-    const f = (x: string) => x.length;
-    expect(Contract(String, Number).enforce(f)('hel')).toBe(3);
-    try {
-      (Contract(String, Number).enforce(f) as any)(3);
-      fail('contract was violated but no exception was thrown');
-      Contract(String, String).enforce(f as any)('hi');
-      fail('contract was violated but no exception was thrown');
-    } catch (e) {
-      /* success */
-    }
-  });
+//   it('1 arg', () => {
+//     const f = (x: string) => x.length;
+//     expect(Contract(String, Number).enforce(f)('hel')).toBe(3);
+//     try {
+//       (Contract(String, Number).enforce(f) as any)(3);
+//       fail('contract was violated but no exception was thrown');
+//       Contract(String, String).enforce(f as any)('hi');
+//       fail('contract was violated but no exception was thrown');
+//     } catch (e) {
+//       /* success */
+//     }
+//   });
 
-  it('2 args', () => {
-    const f = (x: string, y: boolean) => (y ? x.length : 4);
-    expect(Contract(String, Boolean, Number).enforce(f)('hello', false)).toBe(4);
-    try {
-      (Contract(String, Boolean, Number).enforce(f) as any)('hello');
-      fail('contract was violated but no exception was thrown');
-      (Contract(String, Boolean, Number).enforce(f) as any)('hello', 3);
-      fail('contract was violated but no exception was thrown');
-    } catch (e) {
-      /* success */
-    }
-  });
-});
+//   it('2 args', () => {
+//     const f = (x: string, y: boolean) => (y ? x.length : 4);
+//     expect(Contract(String, Boolean, Number).enforce(f)('hello', false)).toBe(4);
+//     try {
+//       (Contract(String, Boolean, Number).enforce(f) as any)('hello');
+//       fail('contract was violated but no exception was thrown');
+//       (Contract(String, Boolean, Number).enforce(f) as any)('hello', 3);
+//       fail('contract was violated but no exception was thrown');
+//     } catch (e) {
+//       /* success */
+//     }
+//   });
+// });
 
-describe('reflection', () => {
-  const X = Literal('x');
-  const Y = Literal('y');
+// describe('reflection', () => {
+//   const X = Literal('x');
+//   const Y = Literal('y');
 
-  it('always', () => {
-    expectLiteralField(Always, 'tag', 'always');
-  });
+//   it('always', () => {
+//     expectLiteralField(Always, 'tag', 'always');
+//   });
 
-  it('never', () => {
-    expectLiteralField(Never, 'tag', 'never');
-  });
+//   it('never', () => {
+//     expectLiteralField(Never, 'tag', 'never');
+//   });
 
-  it('void', () => {
-    expectLiteralField(Void, 'tag', 'void');
-  });
+//   it('void', () => {
+//     expectLiteralField(Void, 'tag', 'void');
+//   });
 
-  it('boolean', () => {
-    expectLiteralField(Boolean, 'tag', 'boolean');
-  });
+//   it('boolean', () => {
+//     expectLiteralField(Boolean, 'tag', 'boolean');
+//   });
 
-  it('number', () => {
-    expectLiteralField(Number, 'tag', 'number');
-  });
+//   it('number', () => {
+//     expectLiteralField(Number, 'tag', 'number');
+//   });
 
-  it('string', () => {
-    expectLiteralField(String, 'tag', 'string');
-  });
+//   it('string', () => {
+//     expectLiteralField(String, 'tag', 'string');
+//   });
 
-  it('literal', () => {
-    expectLiteralField(X, 'tag', 'literal');
-    expectLiteralField(X, 'value', 'x');
-  });
+//   it('literal', () => {
+//     expectLiteralField(X, 'tag', 'literal');
+//     expectLiteralField(X, 'value', 'x');
+//   });
 
-  it('array', () => {
-    expectLiteralField(Array(X), 'tag', 'array');
-    expectLiteralField(Array(X).element, 'tag', 'literal');
-    expectLiteralField(Array(X).element, 'value', 'x');
-  });
+//   it('array', () => {
+//     expectLiteralField(Array(X), 'tag', 'array');
+//     expectLiteralField(Array(X).element, 'tag', 'literal');
+//     expectLiteralField(Array(X).element, 'value', 'x');
+//   });
 
-  it('tuple', () => {
-    expectLiteralField(Tuple(X, X), 'tag', 'tuple');
-    expect(Tuple(X, X).components.map(C => C.tag)).toEqual(['literal', 'literal']);
-    expect(Tuple(X, X).components.map(C => C.value)).toEqual(['x', 'x']);
-  });
+//   it('tuple', () => {
+//     expectLiteralField(Tuple(X, X), 'tag', 'tuple');
+//     expect(Tuple(X, X).components.map(C => C.tag)).toEqual(['literal', 'literal']);
+//     expect(Tuple(X, X).components.map(C => C.value)).toEqual(['x', 'x']);
+//   });
 
-  it('string dictionary', () => {
-    const Rec = Dictionary(Always);
-    expectLiteralField(Rec, 'tag', 'dictionary');
-    expectLiteralField(Rec, 'key', 'string');
-  });
+//   it('string dictionary', () => {
+//     const Rec = Dictionary(Always);
+//     expectLiteralField(Rec, 'tag', 'dictionary');
+//     expectLiteralField(Rec, 'key', 'string');
+//   });
 
-  it('number dictionary', () => {
-    const Rec = Dictionary(Always, 'number');
-    expectLiteralField(Rec, 'tag', 'dictionary');
-    expectLiteralField(Rec, 'key', 'number');
-  });
+//   it('number dictionary', () => {
+//     const Rec = Dictionary(Always, 'number');
+//     expectLiteralField(Rec, 'tag', 'dictionary');
+//     expectLiteralField(Rec, 'key', 'number');
+//   });
 
-  it('record', () => {
-    const Rec = Record({ x: Number, y: Literal(3) });
-    expectLiteralField(Rec, 'tag', 'record');
-    expectLiteralField(Rec.fields.x, 'tag', 'number');
-    expectLiteralField(Rec.fields.y, 'tag', 'literal');
-    expectLiteralField(Rec.fields.y, 'value', 3);
-  });
+//   it('record', () => {
+//     const Rec = Record({ x: Number, y: Literal(3) });
+//     expectLiteralField(Rec, 'tag', 'record');
+//     expectLiteralField(Rec.fields.x, 'tag', 'number');
+//     expectLiteralField(Rec.fields.y, 'tag', 'literal');
+//     expectLiteralField(Rec.fields.y, 'value', 3);
+//   });
 
-  it('partial', () => {
-    const Opt = Partial({ x: Number, y: Literal(3) });
-    expectLiteralField(Opt, 'tag', 'partial');
-    expectLiteralField(Opt.fields.x, 'tag', 'number');
-    expectLiteralField(Opt.fields.y, 'tag', 'literal');
-    expectLiteralField(Opt.fields.y, 'value', 3);
-  });
+//   it('partial', () => {
+//     const Opt = Partial({ x: Number, y: Literal(3) });
+//     expectLiteralField(Opt, 'tag', 'partial');
+//     expectLiteralField(Opt.fields.x, 'tag', 'number');
+//     expectLiteralField(Opt.fields.y, 'tag', 'literal');
+//     expectLiteralField(Opt.fields.y, 'value', 3);
+//   });
 
-  it('union', () => {
-    expectLiteralField(Union(X, Y), 'tag', 'union');
-    expectLiteralField(Union(X, Y), 'tag', 'union');
-    expect(Union(X, Y).alternatives.map(A => A.tag)).toEqual(['literal', 'literal']);
-    expect(Union(X, Y).alternatives.map(A => A.value)).toEqual(['x', 'y']);
-  });
+//   it('union', () => {
+//     expectLiteralField(Union(X, Y), 'tag', 'union');
+//     expectLiteralField(Union(X, Y), 'tag', 'union');
+//     expect(Union(X, Y).alternatives.map(A => A.tag)).toEqual(['literal', 'literal']);
+//     expect(Union(X, Y).alternatives.map(A => A.value)).toEqual(['x', 'y']);
+//   });
 
-  it('intersect', () => {
-    expectLiteralField(Intersect(X, Y), 'tag', 'intersect');
-    expectLiteralField(Intersect(X, Y), 'tag', 'intersect');
-    expect(Intersect(X, Y).intersectees.map(A => A.tag)).toEqual(['literal', 'literal']);
-    expect(Intersect(X, Y).intersectees.map(A => A.value)).toEqual(['x', 'y']);
-  });
+//   it('intersect', () => {
+//     expectLiteralField(Intersect(X, Y), 'tag', 'intersect');
+//     expectLiteralField(Intersect(X, Y), 'tag', 'intersect');
+//     expect(Intersect(X, Y).intersectees.map(A => A.tag)).toEqual(['literal', 'literal']);
+//     expect(Intersect(X, Y).intersectees.map(A => A.value)).toEqual(['x', 'y']);
+//   });
 
-  it('function', () => {
-    expectLiteralField(Function, 'tag', 'function');
-  });
+//   it('function', () => {
+//     expectLiteralField(Function, 'tag', 'function');
+//   });
 
-  it('lazy', () => {
-    const L = Lazy(() => X);
-    expectLiteralField(L, 'tag', 'literal');
-    expectLiteralField(L, 'value', 'x');
-  });
+//   it('lazy', () => {
+//     const L = Lazy(() => X);
+//     expectLiteralField(L, 'tag', 'literal');
+//     expectLiteralField(L, 'value', 'x');
+//   });
 
-  it('constraint', () => {
-    const C = Number.withConstraint(n => n > 9);
-    expectLiteralField(C, 'tag', 'constraint');
-    expectLiteralField(C.underlying, 'tag', 'number');
-  });
+//   it('constraint', () => {
+//     const C = Number.withConstraint(n => n > 9);
+//     expectLiteralField(C, 'tag', 'constraint');
+//     expectLiteralField(C.underlying, 'tag', 'number');
+//   });
 
-  it('instanceof', () => {
-    class Test {}
-    expectLiteralField(InstanceOf(Test), 'tag', 'instanceof');
-    expectLiteralField(Dictionary(Array(InstanceOf(Test))), 'tag', 'dictionary');
-  });
-});
+//   it('instanceof', () => {
+//     class Test {}
+//     expectLiteralField(InstanceOf(Test), 'tag', 'instanceof');
+//     expectLiteralField(Dictionary(Array(InstanceOf(Test))), 'tag', 'dictionary');
+//   });
+// });
 
 // Static tests of reflection
 (

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -46,41 +46,41 @@ class SomeOtherClass {
 }
 
 const runtypes = {
-  // Always,
-  // Never,
-  // Undefined,
-  // Null,
-  // Empty: Record({}),
-  // Void,
-  // Boolean,
-  // true: Literal(true),
-  // false: Literal(false),
-  // Number,
-  // 3: Literal(3),
-  // 42: Literal(42),
-  // String,
-  // 'hello world': Literal('hello world'),
-  // boolArray: Array(Boolean),
-  // boolTuple,
-  // record1,
+  Always,
+  Never,
+  Undefined,
+  Null,
+  Empty: Record({}),
+  Void,
+  Boolean,
+  true: Literal(true),
+  false: Literal(false),
+  Number,
+  3: Literal(3),
+  42: Literal(42),
+  String,
+  'hello world': Literal('hello world'),
+  boolArray: Array(Boolean),
+  boolTuple,
+  record1,
   union1,
   Partial: Partial({ foo: String }).And(Record({ Boolean })),
-  // Function,
-  // Person,
-  // MoreThanThree: Number.withConstraint(n => n > 3),
-  // MoreThanThreeWithMessage: Number.withConstraint(n => n > 3 || `${n} is not greater than 3`),
-  // ArrayNumber: Array(Number),
-  // CustomArray: Array(Number).withConstraint(x => x.length > 3, { tag: 'lenght', min: 3 }),
-  // CustomArrayWithMessage: Array(Number).withConstraint(
-  //   x => x.length > 3 || `Length array is not greater 3`,
-  //   { tag: 'lenght', min: 3 },
-  // ),
-  // Dictionary: Dictionary(String),
-  // NumberDictionary: Dictionary(String, 'number'),
-  // DictionaryOfArrays: Dictionary(Array(Boolean)),
-  // InstanceOfSomeClass: InstanceOf(SomeClass),
-  // InstanceOfSomeOtherClass: InstanceOf(SomeOtherClass),
-  // DictionaryOfArraysOfSomeClass: Dictionary(Array(InstanceOf(SomeClass))),
+  Function,
+  Person,
+  MoreThanThree: Number.withConstraint(n => n > 3),
+  MoreThanThreeWithMessage: Number.withConstraint(n => n > 3 || `${n} is not greater than 3`),
+  ArrayNumber: Array(Number),
+  CustomArray: Array(Number).withConstraint(x => x.length > 3, { tag: 'lenght', min: 3 }),
+  CustomArrayWithMessage: Array(Number).withConstraint(
+    x => x.length > 3 || `Length array is not greater 3`,
+    { tag: 'lenght', min: 3 },
+  ),
+  Dictionary: Dictionary(String),
+  NumberDictionary: Dictionary(String, 'number'),
+  DictionaryOfArrays: Dictionary(Array(Boolean)),
+  InstanceOfSomeClass: InstanceOf(SomeClass),
+  InstanceOfSomeOtherClass: InstanceOf(SomeOtherClass),
+  DictionaryOfArraysOfSomeClass: Dictionary(Array(InstanceOf(SomeClass))),
 };
 
 type RuntypeName = keyof typeof runtypes;
@@ -92,31 +92,31 @@ class Foo {
 } // Should not be recognized as a Dictionary
 
 const testValues: { value: always; passes: RuntypeName[] }[] = [
-  // { value: undefined, passes: ['Undefined', 'Void'] },
-  // { value: null, passes: ['Null', 'Void'] },
-  // { value: true, passes: ['Boolean', 'true'] },
-  // { value: false, passes: ['Boolean', 'false'] },
-  // { value: 3, passes: ['Number', '3', 'union1'] },
-  // { value: 42, passes: ['Number', '42', 'MoreThanThree', 'MoreThanThreeWithMessage'] },
-  // { value: 'hello world', passes: ['String', 'hello world', 'union1'] },
-  // { value: [true, false, true], passes: ['boolArray', 'boolTuple', 'union1'] },
-  // { value: { Boolean: true, Number: 3 }, passes: ['record1', 'union1', 'Partial'] },
+  { value: undefined, passes: ['Undefined', 'Void'] },
+  { value: null, passes: ['Null', 'Void'] },
+  { value: true, passes: ['Boolean', 'true'] },
+  { value: false, passes: ['Boolean', 'false'] },
+  { value: 3, passes: ['Number', '3', 'union1'] },
+  { value: 42, passes: ['Number', '42', 'MoreThanThree', 'MoreThanThreeWithMessage'] },
+  { value: 'hello world', passes: ['String', 'hello world', 'union1'] },
+  { value: [true, false, true], passes: ['boolArray', 'boolTuple', 'union1'] },
+  { value: { Boolean: true, Number: 3 }, passes: ['record1', 'union1', 'Partial'] },
   { value: { Boolean: true }, passes: ['Partial'] },
-  // { value: { Boolean: true, foo: undefined }, passes: ['Partial'] },
-  // { value: { Boolean: true, foo: 'hello' }, passes: ['Partial'] },
-  // { value: { Boolean: true, foo: 5 }, passes: [] },
-  // { value: (x: number, y: string) => x + y.length, passes: ['Function'] },
-  // { value: { name: 'Jimmy', likes: [{ name: 'Peter', likes: [] }] }, passes: ['Person'] },
-  // { value: { a: '1', b: '2' }, passes: ['Dictionary'] },
-  // { value: ['1', '2'], passes: ['NumberDictionary'] },
-  // { value: { 1: '1', 2: '2' }, passes: ['Dictionary', 'NumberDictionary'] },
-  // { value: { a: [], b: [true, false] }, passes: ['DictionaryOfArrays'] },
-  // { value: new Foo(), passes: [] },
-  // { value: [1, 2, 4], passes: ['ArrayNumber'] },
-  // { value: { Boolean: true, Number: '5' }, passes: ['Partial'] },
-  // { value: [1, 2, 3, 4], passes: ['ArrayNumber', 'CustomArray', 'CustomArrayWithMessage'] },
-  // { value: new SomeClass(42), passes: ['InstanceOfSomeClass'] },
-  // { value: { xxx: [new SomeClass(55)] }, passes: ['DictionaryOfArraysOfSomeClass'] },
+  { value: { Boolean: true, foo: undefined }, passes: ['Partial'] },
+  { value: { Boolean: true, foo: 'hello' }, passes: ['Partial'] },
+  { value: { Boolean: true, foo: 5 }, passes: [] },
+  { value: (x: number, y: string) => x + y.length, passes: ['Function'] },
+  { value: { name: 'Jimmy', likes: [{ name: 'Peter', likes: [] }] }, passes: ['Person'] },
+  { value: { a: '1', b: '2' }, passes: ['Dictionary'] },
+  { value: ['1', '2'], passes: ['NumberDictionary'] },
+  { value: { 1: '1', 2: '2' }, passes: ['Dictionary', 'NumberDictionary'] },
+  { value: { a: [], b: [true, false] }, passes: ['DictionaryOfArrays'] },
+  { value: new Foo(), passes: [] },
+  { value: [1, 2, 4], passes: ['ArrayNumber'] },
+  { value: { Boolean: true, Number: '5' }, passes: ['Partial'] },
+  { value: [1, 2, 3, 4], passes: ['ArrayNumber', 'CustomArray', 'CustomArrayWithMessage'] },
+  { value: new SomeClass(42), passes: ['InstanceOfSomeClass'] },
+  { value: { xxx: [new SomeClass(55)] }, passes: ['DictionaryOfArraysOfSomeClass'] },
 ];
 
 for (const { value, passes } of testValues) {
@@ -140,154 +140,154 @@ for (const { value, passes } of testValues) {
   });
 }
 
-// describe('contracts', () => {
-//   it('0 args', () => {
-//     const f = () => 3;
-//     expect(Contract(Number).enforce(f)()).toBe(3);
-//     try {
-//       Contract(String).enforce(f as any)();
-//       fail('contract was violated but no exception was thrown');
-//     } catch (e) {
-//       /* success */
-//     }
-//   });
+describe('contracts', () => {
+  it('0 args', () => {
+    const f = () => 3;
+    expect(Contract(Number).enforce(f)()).toBe(3);
+    try {
+      Contract(String).enforce(f as any)();
+      fail('contract was violated but no exception was thrown');
+    } catch (e) {
+      /* success */
+    }
+  });
 
-//   it('1 arg', () => {
-//     const f = (x: string) => x.length;
-//     expect(Contract(String, Number).enforce(f)('hel')).toBe(3);
-//     try {
-//       (Contract(String, Number).enforce(f) as any)(3);
-//       fail('contract was violated but no exception was thrown');
-//       Contract(String, String).enforce(f as any)('hi');
-//       fail('contract was violated but no exception was thrown');
-//     } catch (e) {
-//       /* success */
-//     }
-//   });
+  it('1 arg', () => {
+    const f = (x: string) => x.length;
+    expect(Contract(String, Number).enforce(f)('hel')).toBe(3);
+    try {
+      (Contract(String, Number).enforce(f) as any)(3);
+      fail('contract was violated but no exception was thrown');
+      Contract(String, String).enforce(f as any)('hi');
+      fail('contract was violated but no exception was thrown');
+    } catch (e) {
+      /* success */
+    }
+  });
 
-//   it('2 args', () => {
-//     const f = (x: string, y: boolean) => (y ? x.length : 4);
-//     expect(Contract(String, Boolean, Number).enforce(f)('hello', false)).toBe(4);
-//     try {
-//       (Contract(String, Boolean, Number).enforce(f) as any)('hello');
-//       fail('contract was violated but no exception was thrown');
-//       (Contract(String, Boolean, Number).enforce(f) as any)('hello', 3);
-//       fail('contract was violated but no exception was thrown');
-//     } catch (e) {
-//       /* success */
-//     }
-//   });
-// });
+  it('2 args', () => {
+    const f = (x: string, y: boolean) => (y ? x.length : 4);
+    expect(Contract(String, Boolean, Number).enforce(f)('hello', false)).toBe(4);
+    try {
+      (Contract(String, Boolean, Number).enforce(f) as any)('hello');
+      fail('contract was violated but no exception was thrown');
+      (Contract(String, Boolean, Number).enforce(f) as any)('hello', 3);
+      fail('contract was violated but no exception was thrown');
+    } catch (e) {
+      /* success */
+    }
+  });
+});
 
-// describe('reflection', () => {
-//   const X = Literal('x');
-//   const Y = Literal('y');
+describe('reflection', () => {
+  const X = Literal('x');
+  const Y = Literal('y');
 
-//   it('always', () => {
-//     expectLiteralField(Always, 'tag', 'always');
-//   });
+  it('always', () => {
+    expectLiteralField(Always, 'tag', 'always');
+  });
 
-//   it('never', () => {
-//     expectLiteralField(Never, 'tag', 'never');
-//   });
+  it('never', () => {
+    expectLiteralField(Never, 'tag', 'never');
+  });
 
-//   it('void', () => {
-//     expectLiteralField(Void, 'tag', 'void');
-//   });
+  it('void', () => {
+    expectLiteralField(Void, 'tag', 'void');
+  });
 
-//   it('boolean', () => {
-//     expectLiteralField(Boolean, 'tag', 'boolean');
-//   });
+  it('boolean', () => {
+    expectLiteralField(Boolean, 'tag', 'boolean');
+  });
 
-//   it('number', () => {
-//     expectLiteralField(Number, 'tag', 'number');
-//   });
+  it('number', () => {
+    expectLiteralField(Number, 'tag', 'number');
+  });
 
-//   it('string', () => {
-//     expectLiteralField(String, 'tag', 'string');
-//   });
+  it('string', () => {
+    expectLiteralField(String, 'tag', 'string');
+  });
 
-//   it('literal', () => {
-//     expectLiteralField(X, 'tag', 'literal');
-//     expectLiteralField(X, 'value', 'x');
-//   });
+  it('literal', () => {
+    expectLiteralField(X, 'tag', 'literal');
+    expectLiteralField(X, 'value', 'x');
+  });
 
-//   it('array', () => {
-//     expectLiteralField(Array(X), 'tag', 'array');
-//     expectLiteralField(Array(X).element, 'tag', 'literal');
-//     expectLiteralField(Array(X).element, 'value', 'x');
-//   });
+  it('array', () => {
+    expectLiteralField(Array(X), 'tag', 'array');
+    expectLiteralField(Array(X).element, 'tag', 'literal');
+    expectLiteralField(Array(X).element, 'value', 'x');
+  });
 
-//   it('tuple', () => {
-//     expectLiteralField(Tuple(X, X), 'tag', 'tuple');
-//     expect(Tuple(X, X).components.map(C => C.tag)).toEqual(['literal', 'literal']);
-//     expect(Tuple(X, X).components.map(C => C.value)).toEqual(['x', 'x']);
-//   });
+  it('tuple', () => {
+    expectLiteralField(Tuple(X, X), 'tag', 'tuple');
+    expect(Tuple(X, X).components.map(C => C.tag)).toEqual(['literal', 'literal']);
+    expect(Tuple(X, X).components.map(C => C.value)).toEqual(['x', 'x']);
+  });
 
-//   it('string dictionary', () => {
-//     const Rec = Dictionary(Always);
-//     expectLiteralField(Rec, 'tag', 'dictionary');
-//     expectLiteralField(Rec, 'key', 'string');
-//   });
+  it('string dictionary', () => {
+    const Rec = Dictionary(Always);
+    expectLiteralField(Rec, 'tag', 'dictionary');
+    expectLiteralField(Rec, 'key', 'string');
+  });
 
-//   it('number dictionary', () => {
-//     const Rec = Dictionary(Always, 'number');
-//     expectLiteralField(Rec, 'tag', 'dictionary');
-//     expectLiteralField(Rec, 'key', 'number');
-//   });
+  it('number dictionary', () => {
+    const Rec = Dictionary(Always, 'number');
+    expectLiteralField(Rec, 'tag', 'dictionary');
+    expectLiteralField(Rec, 'key', 'number');
+  });
 
-//   it('record', () => {
-//     const Rec = Record({ x: Number, y: Literal(3) });
-//     expectLiteralField(Rec, 'tag', 'record');
-//     expectLiteralField(Rec.fields.x, 'tag', 'number');
-//     expectLiteralField(Rec.fields.y, 'tag', 'literal');
-//     expectLiteralField(Rec.fields.y, 'value', 3);
-//   });
+  it('record', () => {
+    const Rec = Record({ x: Number, y: Literal(3) });
+    expectLiteralField(Rec, 'tag', 'record');
+    expectLiteralField(Rec.fields.x, 'tag', 'number');
+    expectLiteralField(Rec.fields.y, 'tag', 'literal');
+    expectLiteralField(Rec.fields.y, 'value', 3);
+  });
 
-//   it('partial', () => {
-//     const Opt = Partial({ x: Number, y: Literal(3) });
-//     expectLiteralField(Opt, 'tag', 'partial');
-//     expectLiteralField(Opt.fields.x, 'tag', 'number');
-//     expectLiteralField(Opt.fields.y, 'tag', 'literal');
-//     expectLiteralField(Opt.fields.y, 'value', 3);
-//   });
+  it('partial', () => {
+    const Opt = Partial({ x: Number, y: Literal(3) });
+    expectLiteralField(Opt, 'tag', 'partial');
+    expectLiteralField(Opt.fields.x, 'tag', 'number');
+    expectLiteralField(Opt.fields.y, 'tag', 'literal');
+    expectLiteralField(Opt.fields.y, 'value', 3);
+  });
 
-//   it('union', () => {
-//     expectLiteralField(Union(X, Y), 'tag', 'union');
-//     expectLiteralField(Union(X, Y), 'tag', 'union');
-//     expect(Union(X, Y).alternatives.map(A => A.tag)).toEqual(['literal', 'literal']);
-//     expect(Union(X, Y).alternatives.map(A => A.value)).toEqual(['x', 'y']);
-//   });
+  it('union', () => {
+    expectLiteralField(Union(X, Y), 'tag', 'union');
+    expectLiteralField(Union(X, Y), 'tag', 'union');
+    expect(Union(X, Y).alternatives.map(A => A.tag)).toEqual(['literal', 'literal']);
+    expect(Union(X, Y).alternatives.map(A => A.value)).toEqual(['x', 'y']);
+  });
 
-//   it('intersect', () => {
-//     expectLiteralField(Intersect(X, Y), 'tag', 'intersect');
-//     expectLiteralField(Intersect(X, Y), 'tag', 'intersect');
-//     expect(Intersect(X, Y).intersectees.map(A => A.tag)).toEqual(['literal', 'literal']);
-//     expect(Intersect(X, Y).intersectees.map(A => A.value)).toEqual(['x', 'y']);
-//   });
+  it('intersect', () => {
+    expectLiteralField(Intersect(X, Y), 'tag', 'intersect');
+    expectLiteralField(Intersect(X, Y), 'tag', 'intersect');
+    expect(Intersect(X, Y).intersectees.map(A => A.tag)).toEqual(['literal', 'literal']);
+    expect(Intersect(X, Y).intersectees.map(A => A.value)).toEqual(['x', 'y']);
+  });
 
-//   it('function', () => {
-//     expectLiteralField(Function, 'tag', 'function');
-//   });
+  it('function', () => {
+    expectLiteralField(Function, 'tag', 'function');
+  });
 
-//   it('lazy', () => {
-//     const L = Lazy(() => X);
-//     expectLiteralField(L, 'tag', 'literal');
-//     expectLiteralField(L, 'value', 'x');
-//   });
+  it('lazy', () => {
+    const L = Lazy(() => X);
+    expectLiteralField(L, 'tag', 'literal');
+    expectLiteralField(L, 'value', 'x');
+  });
 
-//   it('constraint', () => {
-//     const C = Number.withConstraint(n => n > 9);
-//     expectLiteralField(C, 'tag', 'constraint');
-//     expectLiteralField(C.underlying, 'tag', 'number');
-//   });
+  it('constraint', () => {
+    const C = Number.withConstraint(n => n > 9);
+    expectLiteralField(C, 'tag', 'constraint');
+    expectLiteralField(C.underlying, 'tag', 'number');
+  });
 
-//   it('instanceof', () => {
-//     class Test {}
-//     expectLiteralField(InstanceOf(Test), 'tag', 'instanceof');
-//     expectLiteralField(Dictionary(Array(InstanceOf(Test))), 'tag', 'dictionary');
-//   });
-// });
+  it('instanceof', () => {
+    class Test {}
+    expectLiteralField(InstanceOf(Test), 'tag', 'instanceof');
+    expectLiteralField(Dictionary(Array(InstanceOf(Test))), 'tag', 'dictionary');
+  });
+});
 
 // Static tests of reflection
 (

--- a/src/match.spec.ts
+++ b/src/match.spec.ts
@@ -1,7 +1,8 @@
-import { Literal, String, Number, match, Always } from '.';
+import { Record, Array, Literal, String, Number, match, Always } from '.';
+import { Runtype } from './runtype';
 
 describe('match', () => {
-  it('works', () => {
+  it('handles simple cases', () => {
     const f = match(
       [Literal(42), fortyTwo => fortyTwo / 2],
       [Number, n => n + 9],
@@ -19,4 +20,58 @@ describe('match', () => {
     expect(f('yooo')).toBe(8);
     expect(() => f(true)).toThrow('woops');
   });
+
+  it('handles overlaps', () => {
+    const f = match(
+      [Record({ tag: Literal(true), value: Number }), ({ value }) => value * 2],
+      [Record({ tag: Literal(true) }), () => 42],
+    );
+
+    expect(f({ tag: true, value: 3 })).toBe(6);
+    expect(f({ tag: true })).toBe(42);
+  });
+
+  it('performs well', () => {
+    const Str = Counter(String);
+    const Num = Counter(Number);
+
+    const f = match(
+      [Array(Str), arr => arr.reduce((sum, s) => sum + s.length, 0)],
+      [Array(Num), arr => arr.reduce((sum, n) => sum + n, 0)],
+    );
+
+    expect(f(['no', 'te', 'bastardes', 'carborundorum'])).toBe(26);
+    expect(Str.count()).toBe(1);
+    expect(Num.count()).toBe(1);
+
+    Str.reset();
+    Num.reset();
+
+    expect(f([1, 2, 3, 4, 5, 6])).toBe(21);
+    expect(Str.count()).toBe(1);
+    expect(Num.count()).toBe(0);
+  });
 });
+
+interface Counter<A> extends Runtype<A> {
+  count(): number;
+  reset(): void;
+}
+
+const Counter = <A>(A: Runtype<A>): Counter<A> => {
+  let count = 0;
+  return Object.assign(
+    Always.withConstraint(() => {
+      count++;
+      return true;
+    }).And(A),
+    {
+      count() {
+        return count;
+      },
+      reset() {
+        count = 0;
+      },
+    },
+  );
+};

--- a/src/match.ts
+++ b/src/match.ts
@@ -12,7 +12,7 @@ import {
   Matcher1,
   Matcher2,
 } from '.';
-import { Runtype, IncrementalChecker } from './runtype';
+import { Runtype } from './runtype';
 
 export function match<A extends Rt, Z>(a: PairCase<A, Z>): Matcher1<A, Z>;
 export function match<A extends Rt, B extends Rt, Z>(

--- a/src/match.ts
+++ b/src/match.ts
@@ -160,11 +160,14 @@ export function match<Z>(...cases: PairCase<Runtype, Z>[]): (x: any) => Z {
       for (const k of keys) {
         const { checks, handle } = caseRecord[k];
         const { done, value } = checks.next();
+
         if (done && first) return handle(x);
+
         if (value !== undefined) {
           delete caseRecord[k];
           break;
         }
+
         first = false;
       }
     }

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -46,7 +46,7 @@ export interface Runtype<A = any> {
    */
   reflect: Reflect;
 
-  /* @internal */ _checker: IncrementalChecker;
+  /* @internal */ _checkIncrementally: IncrementalChecker;
 
   /* @internal */ _falseWitness: A;
 }
@@ -61,7 +61,7 @@ export function createIncremental<A extends Runtype>(checker: IncrementalChecker
     for (const err of checker(x)) if (err) throw new Error(err);
     return x;
   };
-  A._checker = checker;
+  A._checkIncrementally = checker;
   A.validate = validate;
   A.guard = guard;
   A.Or = Or;
@@ -100,7 +100,7 @@ export function createIncremental<A extends Runtype>(checker: IncrementalChecker
 
 export function create<A extends Runtype>(check: (x: {}) => Static<A>, A: any): A {
   A.check = check;
-  A._checker = checker;
+  A._checkIncrementally = checkIncrementally;
   A.validate = validate;
   A.guard = guard;
   A.Or = Or;
@@ -111,7 +111,7 @@ export function create<A extends Runtype>(check: (x: {}) => Static<A>, A: any): 
 
   return A;
 
-  function* checker(value: any) {
+  function* checkIncrementally(value: any) {
     const result = validate(value);
     yield result.success ? undefined : result.message;
   }

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -113,7 +113,7 @@ export function create<A extends Runtype>(check: (x: {}) => Static<A>, A: any): 
 
   function* checker(value: any) {
     const result = validate(value);
-    if (!result.success) yield result.message;
+    yield result.success ? undefined : result.message;
   }
 
   function validate(value: any): Result<A> {

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -1,4 +1,4 @@
-import { Runtype, Static, create, validationError } from '../runtype';
+import { Runtype, Static, createIncremental } from '../runtype';
 
 interface Arr<E extends Runtype> extends Runtype<Static<E>[]> {
   tag: 'array';
@@ -9,11 +9,10 @@ interface Arr<E extends Runtype> extends Runtype<Static<E>[]> {
  * Construct an array runtype from a runtype for its elements.
  */
 function Arr<E extends Runtype>(element: E): Arr<E> {
-  return create<Arr<E>>(
-    xs => {
-      if (!Array.isArray(xs)) throw validationError(`Expected array but was ${typeof xs}`);
-      for (const x of xs) element.check(x);
-      return xs;
+  return createIncremental<Arr<E>>(
+    function*(xs) {
+      if (!Array.isArray(xs)) yield `Expected array but was ${typeof xs}`;
+      else for (const x of xs) for (const message of element._checker(x)) yield message;
     },
     { tag: 'array', element },
   );

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -12,7 +12,7 @@ function Arr<E extends Runtype>(element: E): Arr<E> {
   return createIncremental<Arr<E>>(
     function*(xs) {
       if (!Array.isArray(xs)) yield `Expected array but was ${typeof xs}`;
-      else for (const x of xs) for (const message of element._checker(x)) yield message;
+      else for (const x of xs) for (const message of element._checkIncrementally(x)) yield message;
     },
     { tag: 'array', element },
   );

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -1,4 +1,4 @@
-import { Runtype, Static, createIncremental, validationError } from '../runtype';
+import { Runtype, Static, createIncremental } from '../runtype';
 import { hasKey } from '../util';
 
 export interface Record<O extends { [_ in string]: Runtype }>

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -18,7 +18,10 @@ export function Record<O extends { [_: string]: Runtype }>(fields: O) {
 
       for (const key in fields) if (!hasKey(key, x)) yield `Missing property ${key}`;
 
-      const checkers = Object.keys(fields).map(key => [key, fields[key]._checker(x[key])]);
+      const checkers = Object.keys(fields).map(key => [
+        key,
+        fields[key]._checkIncrementally(x[key]),
+      ]);
 
       for (const [key, checker] of checkers)
         for (const message of checker)

--- a/src/types/tuple.ts
+++ b/src/types/tuple.ts
@@ -1,6 +1,4 @@
-import { Runtype, Static, create, validationError, createIncremental } from '../runtype';
-import { Always } from './always';
-import { Array as Arr } from './array';
+import { Runtype, Static, createIncremental } from '../runtype';
 
 export interface Tuple1<A extends Runtype> extends Runtype<[Static<A>]> {
   tag: 'tuple';

--- a/src/types/tuple.ts
+++ b/src/types/tuple.ts
@@ -230,7 +230,7 @@ export function Tuple(...components: Runtype[]): any {
       if (x.length < components.length)
         yield `Expected array of ${components.length} but was ${x.length}`;
       for (let i = 0; i < components.length; i++) {
-        for (const message of components[i]._checker(x[i])) {
+        for (const message of components[i]._checkIncrementally(x[i])) {
           yield message;
         }
       }

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -231,11 +231,12 @@ export function Union(...alternatives: Rt[]): any {
         for (const [index, checker] of checkers.entries()) {
           const { done, value } = checker.next();
           if (done) {
-            if (Object.keys(errors).length === checkers.length)
+            if (Object.keys(errors).length === checkers.length) {
               yield 'No alternatives were matched';
+            }
             return;
           }
-          if (errors[index] === undefined) errors[index] = value;
+          if (value !== undefined && errors[index] === undefined) errors[index] = value;
           yield;
         }
       }

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -224,22 +224,18 @@ export function Union(...alternatives: Rt[]): any {
 
   return createIncremental(
     function*(x) {
-      const checkers = alternatives.map(alt => alt._checker(x));
-      const errors: { [k in string]?: string } = {};
-
-      while (true) {
-        for (const [index, checker] of checkers.entries()) {
-          const { done, value } = checker.next();
-          if (done) {
-            if (Object.keys(errors).length === checkers.length) {
-              yield 'No alternatives were matched';
-            }
-            return;
+      for (const checker of alternatives.map(alt => alt._checker(x))) {
+        let foundError = false;
+        for (const message of checker) {
+          if (message !== undefined) {
+            foundError = true;
+            break;
           }
-          if (value !== undefined && errors[index] === undefined) errors[index] = value;
-          yield;
         }
+        if (!foundError) return;
       }
+
+      yield 'No alternatives were matched';
     },
     { tag: 'union', alternatives, match },
   );

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -224,7 +224,7 @@ export function Union(...alternatives: Rt[]): any {
 
   return createIncremental(
     function*(x) {
-      for (const checker of alternatives.map(alt => alt._checker(x))) {
+      for (const checker of alternatives.map(alt => alt._checkIncrementally(x))) {
         let foundError = false;
         for (const message of checker) {
           if (message !== undefined) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "downlevelIteration": true,
     "declaration": true,
     "sourceMap": false,
     "outDir": "lib",


### PR DESCRIPTION
Switches the checking method of composite runtypes to be incremental, using generators. This allows pattern matching to be performed in parallel across cases, which solves the main performance concern raised in #36.

The parallel pattern matching algorithm is roughly as follows:
- in parallel, incrementally check each case
- if a case finds an error, remove it from further consideration
- if a case has finished checking (i.e. was successful) and is the topmost case still under consideration, use that case's handler
- if all but one case has been eliminated, immediately use that case's handler with no further checking. (_"When you have eliminated the impossible, whatever remains, however improbable, must be the truth."_)

A further optimization that could be considered is transforming the provided cases into mutually exclusive cases so that no duplicate work is performed in parallel.

Incremental checking also lays a natural foundation for #8, because the user can keep pulling out as many errors as they like from the runtype's generator.