### PR TITLE
More descriptive errors

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -311,7 +311,7 @@ describe('check errors', () => {
         name: String,
         age: Number,
       }),
-      'Expected number | undefined, but was object',
+      'Expected number, but was null',
       'age',
     );
   });
@@ -324,8 +324,8 @@ describe('check errors', () => {
         age: Number,
         likes: Array(Record({ title: String })),
       }),
-      'Expected { title: string; }[] | undefined, but was object',
-      'likes',
+      'Expected string, but was number',
+      'likes.[0].title',
     );
   });
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -69,11 +69,13 @@ const runtypes = {
   Person,
   MoreThanThree: Number.withConstraint(n => n > 3),
   MoreThanThreeWithMessage: Number.withConstraint(n => n > 3 || `${n} is not greater than 3`),
+  ArrayString: Array(String),
   ArrayNumber: Array(Number),
+  ArrayPerson: Array(Person),
   CustomArray: Array(Number).withConstraint(x => x.length > 3, { tag: 'lenght', min: 3 }),
   CustomArrayWithMessage: Array(Number).withConstraint(
     x => x.length > 3 || `Length array is not greater 3`,
-    { tag: 'lenght', min: 3 },
+    { tag: 'length', min: 3 },
   ),
   Dictionary: Dictionary(String),
   NumberDictionary: Dictionary(String, 'number'),
@@ -106,9 +108,14 @@ const testValues: { value: always; passes: RuntypeName[] }[] = [
   { value: { Boolean: true, foo: 'hello' }, passes: ['Partial'] },
   { value: { Boolean: true, foo: 5 }, passes: [] },
   { value: (x: number, y: string) => x + y.length, passes: ['Function'] },
+  { value: { name: undefined, likes: [] }, passes: [] },
+  { value: { name: 'Jimmy', likes: [{ name: undefined, likes: [] }] }, passes: [] },
   { value: { name: 'Jimmy', likes: [{ name: 'Peter', likes: [] }] }, passes: ['Person'] },
   { value: { a: '1', b: '2' }, passes: ['Dictionary'] },
-  { value: ['1', '2'], passes: ['NumberDictionary'] },
+  { value: ['1', '2'], passes: ['ArrayString', 'NumberDictionary'] },
+  { value: ['1', 2], passes: [] },
+  { value: [{ name: 'Jimmy', likes: [{ name: 'Peter', likes: [] }] }], passes: ['ArrayPerson'] },
+  { value: [{ name: null, likes: [] }], passes: [] },
   { value: { 1: '1', 2: '2' }, passes: ['Dictionary', 'NumberDictionary'] },
   { value: { a: [], b: [true, false] }, passes: ['DictionaryOfArrays'] },
   { value: new Foo(), passes: [] },
@@ -175,6 +182,217 @@ describe('contracts', () => {
       fail('contract was violated but no exception was thrown');
     } catch (e) {
       /* success */
+    }
+  });
+});
+
+describe('check errors', () => {
+  it('tuple type', () => {
+    try {
+      const Check = Tuple(Number, String, Boolean);
+      Check.check([false, '0', true]);
+      fail("tuple passed, eventhough should've failed");
+    } catch (e) {
+      expect(e.message).toBe('Expected a number, but was boolean');
+      expect(e.key).toBe('[0]');
+    }
+  });
+
+  it('tuple length', () => {
+    try {
+      const Check = Tuple(Number, String, Boolean);
+      Check.check([0, '0']);
+      fail("tuple passed, eventhough should've failed");
+    } catch (e) {
+      expect(e.message).toBe('Expected an array of 3, but was 2');
+      expect(e.key).toBe(undefined);
+    }
+  });
+
+  it('tuple nested', () => {
+    try {
+      const Nested = Record({ name: String });
+      const Check = Tuple(Number, Nested);
+      Check.check([0, { name: 0 }]);
+      fail("tuple passed eventough should've failed");
+    } catch (e) {
+      expect(e.message).toBe('Expected a string, but was number');
+      expect(e.key).toBe('[1].name');
+    }
+  });
+
+  it('array', () => {
+    try {
+      const Check = Array(Number);
+      Check.check([0, 2, 'test']);
+      fail("array passed eventough should've failed");
+    } catch (e) {
+      expect(e.message).toBe('Expected a number, but was string');
+      expect(e.key).toBe('[2]');
+    }
+  });
+
+  it('array nested', () => {
+    try {
+      const Nested = Record({ name: String });
+      const Check = Array(Nested);
+      Check.check([{ name: 'Foo' }, { name: false }]);
+      fail("array passed eventough should've failed");
+    } catch (e) {
+      expect(e.message).toBe('Expected a string, but was boolean');
+      expect(e.key).toBe('[1].name');
+    }
+  });
+
+  it('array null', () => {
+    try {
+      const Nested = Record({ name: String });
+      const Check = Array(Nested);
+      Check.check([{ name: 'Foo' }, null]);
+      fail("array passed eventough should've failed");
+    } catch (e) {
+      expect(e.message).toBe('Expected { name: string; }, but was null');
+      expect(e.key).toBe('[1]');
+    }
+  });
+
+  it('dictionary', () => {
+    try {
+      const Check = Dictionary(String);
+      Check.check(null);
+      fail("dictionary passed eventough should've failed");
+    } catch (e) {
+      expect(e.message).toBe('Expected a dictionary [string: string], but was null');
+      expect(e.key).toBe(undefined);
+    }
+  });
+
+  it('dictionary invalid type', () => {
+    try {
+      const Value = Record({ name: String });
+      const Check = Dictionary(Value);
+      Check.check(undefined);
+      fail("dictionary passed eventough should've failed");
+    } catch (e) {
+      expect(e.message).toBe(
+        'Expected a dictionary [string: { name: string; }], but was undefined',
+      );
+      expect(e.key).toBe(undefined);
+    }
+
+    try {
+      const Value = Record({ name: String });
+      const Check = Dictionary(Value);
+      Check.check(1);
+      fail("dictionary passed eventough should've failed");
+    } catch (e) {
+      expect(e.message).toBe('Expected a dictionary [string: { name: string; }], but was number');
+      expect(e.key).toBe(undefined);
+    }
+  });
+
+  it('dictionary complex', () => {
+    try {
+      const Value = Record({ name: String });
+      const Check = Dictionary(Value);
+      Check.check({ foo: { name: false } });
+      fail("dictionary passed eventough should've failed");
+    } catch (e) {
+      expect(e.message).toBe('Expected a string, but was boolean');
+      expect(e.key).toBe('foo.name');
+    }
+  });
+
+  it('string dictionary', () => {
+    try {
+      const Check = Dictionary(String);
+      Check.check({ foo: 'bar', test: true });
+      fail("dictionary passed eventough should've failed");
+    } catch (e) {
+      expect(e.message).toBe('Expected a string, but was boolean');
+      expect(e.key).toBe('test');
+    }
+  });
+
+  it('number dictionary', () => {
+    try {
+      const Check = Dictionary(String, 'number');
+      Check.check({ 1: 'bar', 2: 20 });
+      fail("dictionary passed eventough should've failed");
+    } catch (e) {
+      expect(e.message).toBe('Expected a string, but was number');
+      expect(e.key).toBe('2');
+    }
+  });
+
+  it('record', () => {
+    try {
+      const Check = Record({
+        name: String,
+        age: Number,
+      });
+      Check.check({ name: 'Jack', age: '10' });
+      fail("record passed eventough should've failed");
+    } catch (e) {
+      expect(e.message).toBe('Expected a number, but was string');
+      expect(e.key).toBe('age');
+    }
+  });
+
+  it('record complex', () => {
+    try {
+      const Check = Record({
+        name: String,
+        age: Number,
+        likes: Array(Record({ title: String })),
+      });
+      Check.check({ name: 'Jack', age: 10, likes: [{ title: false }] });
+      fail("record passed eventough should've failed");
+    } catch (e) {
+      expect(e.message).toBe('Expected a string, but was boolean');
+      expect(e.key).toBe('likes.[0].title');
+    }
+  });
+
+  it('partial', () => {
+    try {
+      const Check = Partial({
+        name: String,
+        age: Number,
+      });
+      Check.check({ name: 'Jack', age: null });
+      fail("partial passed eventhough should've failed");
+    } catch (e) {
+      expect(e.message).toBe('Expected a number | undefined, but was object null');
+      expect(e.key).toBe('age');
+    }
+  });
+
+  it('partial complex', () => {
+    try {
+      const Check = Partial({
+        name: String,
+        age: Number,
+        likes: Array(Record({ title: String })),
+      });
+      Check.check({ name: 'Jack', likes: [{ title: 2 }] });
+      fail("partial passed eventhough should've failed");
+    } catch (e) {
+      expect(e.message).toBe(
+        'Expected a { title: string; }[] | undefined, but was object [{"title":2}]',
+      );
+      expect(e.key).toBe('likes');
+    }
+  });
+
+  it('union', () => {
+    try {
+      const Check = Union(Number, String);
+      Check.check(false);
+      fail("union passed eventhough should've failed");
+    } catch (e) {
+      expect(e.message).toBe('Expected a number | string, but was boolean false');
+      expect(e.key).toBe(undefined);
     }
   });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -188,212 +188,149 @@ describe('contracts', () => {
 
 describe('check errors', () => {
   it('tuple type', () => {
-    try {
-      const Check = Tuple(Number, String, Boolean);
-      Check.check([false, '0', true]);
-      fail("tuple passed, eventhough should've failed");
-    } catch (e) {
-      expect(e.message).toBe('Expected a number, but was boolean');
-      expect(e.key).toBe('[0]');
-    }
+    assertThrows(
+      [false, '0', true],
+      Tuple(Number, String, Boolean),
+      'Expected number, but was boolean',
+      '[0]',
+    );
   });
 
   it('tuple length', () => {
-    try {
-      const Check = Tuple(Number, String, Boolean);
-      Check.check([0, '0']);
-      fail("tuple passed, eventhough should've failed");
-    } catch (e) {
-      expect(e.message).toBe('Expected an array of 3, but was 2');
-      expect(e.key).toBe(undefined);
-    }
+    assertThrows(
+      [0, '0'],
+      Tuple(Number, String, Boolean),
+      'Expected an array of length 3, but was 2',
+    );
   });
 
   it('tuple nested', () => {
-    try {
-      const Nested = Record({ name: String });
-      const Check = Tuple(Number, Nested);
-      Check.check([0, { name: 0 }]);
-      fail("tuple passed eventough should've failed");
-    } catch (e) {
-      expect(e.message).toBe('Expected a string, but was number');
-      expect(e.key).toBe('[1].name');
-    }
+    assertThrows(
+      [0, { name: 0 }],
+      Tuple(Number, Record({ name: String })),
+      'Expected string, but was number',
+      '[1].name',
+    );
   });
 
   it('array', () => {
-    try {
-      const Check = Array(Number);
-      Check.check([0, 2, 'test']);
-      fail("array passed eventough should've failed");
-    } catch (e) {
-      expect(e.message).toBe('Expected a number, but was string');
-      expect(e.key).toBe('[2]');
-    }
+    assertThrows([0, 2, 'test'], Array(Number), 'Expected number, but was string', '[2]');
   });
 
   it('array nested', () => {
-    try {
-      const Nested = Record({ name: String });
-      const Check = Array(Nested);
-      Check.check([{ name: 'Foo' }, { name: false }]);
-      fail("array passed eventough should've failed");
-    } catch (e) {
-      expect(e.message).toBe('Expected a string, but was boolean');
-      expect(e.key).toBe('[1].name');
-    }
+    assertThrows(
+      [{ name: 'Foo' }, { name: false }],
+      Array(Record({ name: String })),
+      'Expected string, but was boolean',
+      '[1].name',
+    );
   });
 
   it('array null', () => {
-    try {
-      const Nested = Record({ name: String });
-      const Check = Array(Nested);
-      Check.check([{ name: 'Foo' }, null]);
-      fail("array passed eventough should've failed");
-    } catch (e) {
-      expect(e.message).toBe('Expected { name: string; }, but was null');
-      expect(e.key).toBe('[1]');
-    }
+    assertThrows(
+      [{ name: 'Foo' }, null],
+      Array(Record({ name: String })),
+      'Expected { name: string; }, but was null',
+      '[1]',
+    );
   });
 
   it('dictionary', () => {
-    try {
-      const Check = Dictionary(String);
-      Check.check(null);
-      fail("dictionary passed eventough should've failed");
-    } catch (e) {
-      expect(e.message).toBe('Expected a dictionary [string: string], but was null');
-      expect(e.key).toBe(undefined);
-    }
+    assertThrows(null, Dictionary(String), 'Expected dictionary [string: string], but was null');
   });
 
   it('dictionary invalid type', () => {
-    try {
-      const Value = Record({ name: String });
-      const Check = Dictionary(Value);
-      Check.check(undefined);
-      fail("dictionary passed eventough should've failed");
-    } catch (e) {
-      expect(e.message).toBe(
-        'Expected a dictionary [string: { name: string; }], but was undefined',
-      );
-      expect(e.key).toBe(undefined);
-    }
-
-    try {
-      const Value = Record({ name: String });
-      const Check = Dictionary(Value);
-      Check.check(1);
-      fail("dictionary passed eventough should've failed");
-    } catch (e) {
-      expect(e.message).toBe('Expected a dictionary [string: { name: string; }], but was number');
-      expect(e.key).toBe(undefined);
-    }
+    assertThrows(
+      undefined,
+      Dictionary(Record({ name: String })),
+      'Expected dictionary [string: { name: string; }], but was undefined',
+    );
+    assertThrows(
+      1,
+      Dictionary(Record({ name: String })),
+      'Expected dictionary [string: { name: string; }], but was number',
+    );
   });
 
   it('dictionary complex', () => {
-    try {
-      const Value = Record({ name: String });
-      const Check = Dictionary(Value);
-      Check.check({ foo: { name: false } });
-      fail("dictionary passed eventough should've failed");
-    } catch (e) {
-      expect(e.message).toBe('Expected a string, but was boolean');
-      expect(e.key).toBe('foo.name');
-    }
+    assertThrows(
+      { foo: { name: false } },
+      Dictionary(Record({ name: String })),
+      'Expected string, but was boolean',
+      'foo.name',
+    );
   });
 
   it('string dictionary', () => {
-    try {
-      const Check = Dictionary(String);
-      Check.check({ foo: 'bar', test: true });
-      fail("dictionary passed eventough should've failed");
-    } catch (e) {
-      expect(e.message).toBe('Expected a string, but was boolean');
-      expect(e.key).toBe('test');
-    }
+    assertThrows(
+      { foo: 'bar', test: true },
+      Dictionary(String),
+      'Expected string, but was boolean',
+      'test',
+    );
   });
 
   it('number dictionary', () => {
-    try {
-      const Check = Dictionary(String, 'number');
-      Check.check({ 1: 'bar', 2: 20 });
-      fail("dictionary passed eventough should've failed");
-    } catch (e) {
-      expect(e.message).toBe('Expected a string, but was number');
-      expect(e.key).toBe('2');
-    }
+    assertThrows(
+      { 1: 'bar', 2: 20 },
+      Dictionary(String, 'number'),
+      'Expected string, but was number',
+      '2',
+    );
   });
 
   it('record', () => {
-    try {
-      const Check = Record({
+    assertThrows(
+      { name: 'Jack', age: '10' },
+      Record({
         name: String,
         age: Number,
-      });
-      Check.check({ name: 'Jack', age: '10' });
-      fail("record passed eventough should've failed");
-    } catch (e) {
-      expect(e.message).toBe('Expected a number, but was string');
-      expect(e.key).toBe('age');
-    }
+      }),
+      'Expected number, but was string',
+      'age',
+    );
   });
 
   it('record complex', () => {
-    try {
-      const Check = Record({
+    assertThrows(
+      { name: 'Jack', age: 10, likes: [{ title: false }] },
+      Record({
         name: String,
         age: Number,
         likes: Array(Record({ title: String })),
-      });
-      Check.check({ name: 'Jack', age: 10, likes: [{ title: false }] });
-      fail("record passed eventough should've failed");
-    } catch (e) {
-      expect(e.message).toBe('Expected a string, but was boolean');
-      expect(e.key).toBe('likes.[0].title');
-    }
+      }),
+      'Expected string, but was boolean',
+      'likes.[0].title',
+    );
   });
 
   it('partial', () => {
-    try {
-      const Check = Partial({
+    assertThrows(
+      { name: 'Jack', age: null },
+      Partial({
         name: String,
         age: Number,
-      });
-      Check.check({ name: 'Jack', age: null });
-      fail("partial passed eventhough should've failed");
-    } catch (e) {
-      expect(e.message).toBe('Expected a number | undefined, but was object null');
-      expect(e.key).toBe('age');
-    }
+      }),
+      'Expected number | undefined, but was object null',
+      'age',
+    );
   });
 
   it('partial complex', () => {
-    try {
-      const Check = Partial({
+    assertThrows(
+      { name: 'Jack', likes: [{ title: 2 }] },
+      Partial({
         name: String,
         age: Number,
         likes: Array(Record({ title: String })),
-      });
-      Check.check({ name: 'Jack', likes: [{ title: 2 }] });
-      fail("partial passed eventhough should've failed");
-    } catch (e) {
-      expect(e.message).toBe(
-        'Expected a { title: string; }[] | undefined, but was object [{"title":2}]',
-      );
-      expect(e.key).toBe('likes');
-    }
+      }),
+      'Expected { title: string; }[] | undefined, but was object [{"title":2}]',
+      'likes',
+    );
   });
 
   it('union', () => {
-    try {
-      const Check = Union(Number, String);
-      Check.check(false);
-      fail("union passed eventhough should've failed");
-    } catch (e) {
-      expect(e.message).toBe('Expected a number | string, but was boolean false');
-      expect(e.key).toBe(undefined);
-    }
+    assertThrows(false, Union(Number, String), 'Expected number | string, but was boolean false');
   });
 });
 
@@ -594,4 +531,14 @@ function assertAccepts<A>(value: always, runtype: Runtype<A>) {
 function assertRejects<A>(value: always, runtype: Runtype<A>) {
   const result = runtype.validate(value);
   if (result.success === true) fail('value passed validation even though it was not expected to');
+}
+
+function assertThrows<A>(value: always, runtype: Runtype<A>, error: string, key?: string) {
+  try {
+    runtype.check(value);
+    fail('value passed validation even though it was not expected to');
+  } catch ({ message: errorMessage, key: errorKey }) {
+    expect(errorMessage).toBe(error);
+    expect(errorKey).toBe(key);
+  }
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -236,23 +236,19 @@ describe('check errors', () => {
   });
 
   it('dictionary', () => {
-    assertThrows(
-      null,
-      Dictionary(String),
-      'Expected dictionary { [_: string]: string }, but was null',
-    );
+    assertThrows(null, Dictionary(String), 'Expected { [_: string]: string }, but was null');
   });
 
   it('dictionary invalid type', () => {
     assertThrows(
       undefined,
       Dictionary(Record({ name: String })),
-      'Expected dictionary { [_: string]: { name: string; } }, but was undefined',
+      'Expected { [_: string]: { name: string; } }, but was undefined',
     );
     assertThrows(
       1,
       Dictionary(Record({ name: String })),
-      'Expected dictionary { [_: string]: { name: string; } }, but was number',
+      'Expected { [_: string]: { name: string; } }, but was number',
     );
   });
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -236,19 +236,23 @@ describe('check errors', () => {
   });
 
   it('dictionary', () => {
-    assertThrows(null, Dictionary(String), 'Expected dictionary [string: string], but was null');
+    assertThrows(
+      null,
+      Dictionary(String),
+      'Expected dictionary { [_: string]: string }, but was null',
+    );
   });
 
   it('dictionary invalid type', () => {
     assertThrows(
       undefined,
       Dictionary(Record({ name: String })),
-      'Expected dictionary [string: { name: string; }], but was undefined',
+      'Expected dictionary { [_: string]: { name: string; } }, but was undefined',
     );
     assertThrows(
       1,
       Dictionary(Record({ name: String })),
-      'Expected dictionary [string: { name: string; }], but was number',
+      'Expected dictionary { [_: string]: { name: string; } }, but was number',
     );
   });
 
@@ -311,7 +315,7 @@ describe('check errors', () => {
         name: String,
         age: Number,
       }),
-      'Expected number | undefined, but was object null',
+      'Expected number | undefined, but was object',
       'age',
     );
   });
@@ -324,13 +328,13 @@ describe('check errors', () => {
         age: Number,
         likes: Array(Record({ title: String })),
       }),
-      'Expected { title: string; }[] | undefined, but was object [{"title":2}]',
+      'Expected { title: string; }[] | undefined, but was object',
       'likes',
     );
   });
 
   it('union', () => {
-    assertThrows(false, Union(Number, String), 'Expected number | string, but was boolean false');
+    assertThrows(false, Union(Number, String), 'Expected number | string, but was boolean');
   });
 });
 

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -93,11 +93,14 @@ export function create<A extends Runtype>(check: (x: {}) => Static<A>, A: any): 
 }
 
 export class ValidationError extends Error {
-  constructor(message: string) {
+  key?: string;
+
+  constructor(message: string, key?: string) {
     super(message);
+    this.key = key;
   }
 }
 
-export function validationError(message: string) {
-  return new ValidationError(message);
+export function validationError(message: string, key?: string) {
+  return new ValidationError(message, key);
 }

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -11,7 +11,7 @@ interface Arr<E extends Runtype> extends Runtype<Static<E>[]> {
 function Arr<E extends Runtype>(element: E): Arr<E> {
   return create<Arr<E>>(
     xs => {
-      if (!Array.isArray(xs)) throw validationError(`Expected an array, but was ${typeof xs}`);
+      if (!Array.isArray(xs)) throw validationError(`Expected array, but was ${typeof xs}`);
 
       for (const x of xs) {
         try {

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -11,8 +11,16 @@ interface Arr<E extends Runtype> extends Runtype<Static<E>[]> {
 function Arr<E extends Runtype>(element: E): Arr<E> {
   return create<Arr<E>>(
     xs => {
-      if (!Array.isArray(xs)) throw validationError(`Expected array but was ${typeof xs}`);
-      for (const x of xs) element.check(x);
+      if (!Array.isArray(xs)) throw validationError(`Expected an array, but was ${typeof xs}`);
+
+      for (const x of xs) {
+        try {
+          element.check(x);
+        } catch ({ message, key }) {
+          throw validationError(message, key ? `[${xs.indexOf(x)}].${key}` : `[${xs.indexOf(x)}]`);
+        }
+      }
+
       return xs;
     },
     { tag: 'array', element },

--- a/src/types/boolean.ts
+++ b/src/types/boolean.ts
@@ -9,7 +9,7 @@ export interface Boolean extends Runtype<boolean> {
  */
 export const Boolean = create<Boolean>(
   x => {
-    if (typeof x !== 'boolean') throw validationError(`Expected a boolean, but was ${typeof x}`);
+    if (typeof x !== 'boolean') throw validationError(`Expected boolean, but was ${typeof x}`);
     return x;
   },
   { tag: 'boolean' },

--- a/src/types/boolean.ts
+++ b/src/types/boolean.ts
@@ -9,7 +9,7 @@ export interface Boolean extends Runtype<boolean> {
  */
 export const Boolean = create<Boolean>(
   x => {
-    if (typeof x !== 'boolean') throw validationError(`Expected boolean but was ${typeof x}`);
+    if (typeof x !== 'boolean') throw validationError(`Expected a boolean, but was ${typeof x}`);
     return x;
   },
   { tag: 'boolean' },

--- a/src/types/dictionary.ts
+++ b/src/types/dictionary.ts
@@ -1,5 +1,4 @@
 import { Runtype, create, Static, validationError } from '../runtype';
-import { Record } from './record';
 import show from '../show';
 
 export interface StringDictionary<V extends Runtype> extends Runtype<{ [_: string]: Static<V> }> {
@@ -22,28 +21,20 @@ export function Dictionary<V extends Runtype>(value: V, key?: 'number'): NumberD
 export function Dictionary<V extends Runtype>(value: V, key = 'string'): any {
   return create<Runtype>(
     x => {
-      try {
-        Record({}).check(x);
-      } catch (e) {
+      if (x === null || x === undefined) {
         const a = create<any>(x as never, { tag: 'dictionary', key, value });
-        throw validationError(
-          `Expected dictionary ${show(a.reflect)}, but was ${
-            x === undefined || x === null ? x : typeof x
-          }`,
-        );
+        throw validationError(`Expected ${show(a)}, but was ${x}`);
       }
 
       if (typeof x !== 'object') {
         const a = create<any>(x as never, { tag: 'dictionary', key, value });
-        throw validationError(`Expected dictionary ${show(a.reflect)}, but was ${typeof x}`);
+        throw validationError(`Expected ${show(a.reflect)}, but was ${typeof x}`);
       }
 
       if (Object.getPrototypeOf(x) !== Object.prototype) {
         if (!Array.isArray(x)) {
           const a = create<any>(x as never, { tag: 'dictionary', key, value });
-          throw validationError(
-            `Expected dictionary ${show(a.reflect)}, but was ${Object.getPrototypeOf(x)}`,
-          );
+          throw validationError(`Expected ${show(a.reflect)}, but was ${Object.getPrototypeOf(x)}`);
         } else if (key === 'string') throw validationError(`Expected dictionary, but was array`);
       }
 

--- a/src/types/dictionary.ts
+++ b/src/types/dictionary.ts
@@ -1,5 +1,6 @@
 import { Runtype, create, Static, validationError } from '../runtype';
 import { Record } from './record';
+import show from '../show';
 
 export interface StringDictionary<V extends Runtype> extends Runtype<{ [_: string]: Static<V> }> {
   tag: 'dictionary';
@@ -21,22 +22,41 @@ export function Dictionary<V extends Runtype>(value: V, key?: 'number'): NumberD
 export function Dictionary<V extends Runtype>(value: V, key = 'string'): any {
   return create<Runtype>(
     x => {
-      Record({}).check(x);
+      try {
+        Record({}).check(x);
+      } catch (e) {
+        throw validationError(
+          `Expected a dictionary [${key}: ${show(value.reflect)}], but was ${
+            x === undefined || x === null ? x : typeof x
+          }`,
+        );
+      }
 
-      if (typeof x !== 'object') throw validationError(`Expected an object but was ${typeof x}`);
+      if (typeof x !== 'object')
+        throw validationError(
+          `Expected a dictionary [${key}: ${show(value.reflect)}], but was ${typeof x}`,
+        );
 
       if (Object.getPrototypeOf(x) !== Object.prototype) {
-        if (!Array.isArray(x)) throw validationError(`Expected simple object but was complex`);
-        else if (key === 'string') throw validationError(`Expected dictionary but was array`);
+        if (!Array.isArray(x))
+          throw validationError(
+            `Expected a dictionary [${key}: ${value}], but was ${Object.getPrototypeOf(x)}`,
+          );
+        else if (key === 'string') throw validationError(`Expected a dictionary, but was array`);
       }
 
       for (const k in x) {
         // Object keys are always strings
         if (key === 'number') {
           if (isNaN(+k))
-            throw validationError(`Expected dictionary key to be a number but was string`);
+            throw validationError(`Expected dictionary key to be a number, but was string`);
         }
-        value.check((x as any)[k]);
+
+        try {
+          value.check((x as any)[k]);
+        } catch ({ key: nestedKey, message }) {
+          throw validationError(message, nestedKey ? `${k}.${nestedKey}` : k);
+        }
       }
 
       return x;

--- a/src/types/dictionary.ts
+++ b/src/types/dictionary.ts
@@ -25,24 +25,26 @@ export function Dictionary<V extends Runtype>(value: V, key = 'string'): any {
       try {
         Record({}).check(x);
       } catch (e) {
+        const a = create<any>(x as never, { tag: 'dictionary', key, value });
         throw validationError(
-          `Expected dictionary [${key}: ${show(value.reflect)}], but was ${
+          `Expected dictionary ${show(a.reflect)}, but was ${
             x === undefined || x === null ? x : typeof x
           }`,
         );
       }
 
-      if (typeof x !== 'object')
-        throw validationError(
-          `Expected dictionary [${key}: ${show(value.reflect)}], but was ${typeof x}`,
-        );
+      if (typeof x !== 'object') {
+        const a = create<any>(x as never, { tag: 'dictionary', key, value });
+        throw validationError(`Expected dictionary ${show(a.reflect)}, but was ${typeof x}`);
+      }
 
       if (Object.getPrototypeOf(x) !== Object.prototype) {
-        if (!Array.isArray(x))
+        if (!Array.isArray(x)) {
+          const a = create<any>(x as never, { tag: 'dictionary', key, value });
           throw validationError(
-            `Expected dictionary [${key}: ${value}], but was ${Object.getPrototypeOf(x)}`,
+            `Expected dictionary ${show(a.reflect)}, but was ${Object.getPrototypeOf(x)}`,
           );
-        else if (key === 'string') throw validationError(`Expected dictionary, but was array`);
+        } else if (key === 'string') throw validationError(`Expected dictionary, but was array`);
       }
 
       for (const k in x) {

--- a/src/types/dictionary.ts
+++ b/src/types/dictionary.ts
@@ -26,7 +26,7 @@ export function Dictionary<V extends Runtype>(value: V, key = 'string'): any {
         Record({}).check(x);
       } catch (e) {
         throw validationError(
-          `Expected a dictionary [${key}: ${show(value.reflect)}], but was ${
+          `Expected dictionary [${key}: ${show(value.reflect)}], but was ${
             x === undefined || x === null ? x : typeof x
           }`,
         );
@@ -34,15 +34,15 @@ export function Dictionary<V extends Runtype>(value: V, key = 'string'): any {
 
       if (typeof x !== 'object')
         throw validationError(
-          `Expected a dictionary [${key}: ${show(value.reflect)}], but was ${typeof x}`,
+          `Expected dictionary [${key}: ${show(value.reflect)}], but was ${typeof x}`,
         );
 
       if (Object.getPrototypeOf(x) !== Object.prototype) {
         if (!Array.isArray(x))
           throw validationError(
-            `Expected a dictionary [${key}: ${value}], but was ${Object.getPrototypeOf(x)}`,
+            `Expected dictionary [${key}: ${value}], but was ${Object.getPrototypeOf(x)}`,
           );
-        else if (key === 'string') throw validationError(`Expected a dictionary, but was array`);
+        else if (key === 'string') throw validationError(`Expected dictionary, but was array`);
       }
 
       for (const k in x) {

--- a/src/types/function.ts
+++ b/src/types/function.ts
@@ -9,7 +9,7 @@ export interface Function extends Runtype<(...args: any[]) => any> {
  */
 export const Function = create<Function>(
   x => {
-    if (typeof x !== 'function') throw validationError(`Expected a function, but was ${typeof x}`);
+    if (typeof x !== 'function') throw validationError(`Expected function, but was ${typeof x}`);
     return x;
   },
   { tag: 'function' },

--- a/src/types/function.ts
+++ b/src/types/function.ts
@@ -9,7 +9,7 @@ export interface Function extends Runtype<(...args: any[]) => any> {
  */
 export const Function = create<Function>(
   x => {
-    if (typeof x !== 'function') throw validationError(`Expected a function but was ${typeof x}`);
+    if (typeof x !== 'function') throw validationError(`Expected a function, but was ${typeof x}`);
     return x;
   },
   { tag: 'function' },

--- a/src/types/instanceof.ts
+++ b/src/types/instanceof.ts
@@ -13,7 +13,7 @@ export function InstanceOf<V>(ctor: Constructor<V>) {
   return create<InstanceOf<V>>(
     x => {
       if (!(x instanceof ctor)) {
-        throw validationError(`Expected a ${(ctor as any).name} but was ${typeof x}`);
+        throw validationError(`Expected a ${(ctor as any).name}, but was ${typeof x}`);
       }
       return x as V;
     },

--- a/src/types/instanceof.ts
+++ b/src/types/instanceof.ts
@@ -13,7 +13,7 @@ export function InstanceOf<V>(ctor: Constructor<V>) {
   return create<InstanceOf<V>>(
     x => {
       if (!(x instanceof ctor)) {
-        throw validationError(`Expected a ${(ctor as any).name}, but was ${typeof x}`);
+        throw validationError(`Expected ${(ctor as any).name}, but was ${typeof x}`);
       }
       return x as V;
     },

--- a/src/types/literal.ts
+++ b/src/types/literal.ts
@@ -16,7 +16,7 @@ export interface Literal<A extends LiteralBase> extends Runtype<A> {
 export function Literal<A extends LiteralBase>(value: A): Literal<A> {
   return create<Literal<A>>(
     x => {
-      if (x !== value) throw validationError(`Expected literal '${value}' but was '${x}'`);
+      if (x !== value) throw validationError(`Expected literal '${value}', but was '${x}'`);
       return x as A;
     },
     { tag: 'literal', value },

--- a/src/types/never.ts
+++ b/src/types/never.ts
@@ -8,8 +8,8 @@ export interface Never extends Runtype<never> {
  * Validates nothing (always fails).
  */
 export const Never = create<Never>(
-  () => {
-    throw validationError('Expected nothing but got something');
+  x => {
+    throw validationError(`Expected nothing, but was ${x}`);
   },
   { tag: 'never' },
 );

--- a/src/types/number.ts
+++ b/src/types/number.ts
@@ -11,7 +11,7 @@ export const Number = create<Number>(
   x => {
     if (typeof x !== 'number')
       throw validationError(
-        `Expected a number, but was ${x === null || x === undefined ? x : typeof x}`,
+        `Expected number, but was ${x === null || x === undefined ? x : typeof x}`,
       );
     return x;
   },

--- a/src/types/number.ts
+++ b/src/types/number.ts
@@ -9,7 +9,10 @@ export interface Number extends Runtype<number> {
  */
 export const Number = create<Number>(
   x => {
-    if (typeof x !== 'number') throw validationError(`Expected number but was ${typeof x}`);
+    if (typeof x !== 'number')
+      throw validationError(
+        `Expected a number, but was ${x === null || x === undefined ? x : typeof x}`,
+      );
     return x;
   },
   { tag: 'number' },

--- a/src/types/partial.ts
+++ b/src/types/partial.ts
@@ -27,8 +27,8 @@ export function Part<O extends { [_: string]: Runtype }>(fields: O) {
           let FieldType = Union(fields[key], Undefined);
           try {
             FieldType.check(x[key]);
-          } catch ({ message, key: nestedKey }) {
-            throw validationError(message, nestedKey ? `${key}.${nestedKey}` : key);
+          } catch ({ message }) {
+            throw validationError(message, key);
           }
         }
 

--- a/src/types/partial.ts
+++ b/src/types/partial.ts
@@ -1,6 +1,4 @@
 import { Runtype, Static, create, validationError } from '../runtype';
-import { Union } from '../index';
-import { Undefined } from './literal';
 import { hasKey } from '../util';
 import show from '../show';
 
@@ -22,15 +20,15 @@ export function Part<O extends { [_: string]: Runtype }>(fields: O) {
       }
 
       // tslint:disable-next-line:forin
-      for (const key in fields)
-        if (hasKey(key, x)) {
-          let FieldType = Union(fields[key], Undefined);
+      for (const key in fields) {
+        if (hasKey(key, x) && x[key] !== undefined) {
           try {
-            FieldType.check(x[key]);
-          } catch ({ message }) {
-            throw validationError(message, key);
+            fields[key].check(x[key]);
+          } catch ({ message, key: nestedKey }) {
+            throw validationError(message, nestedKey ? `${key}.${nestedKey}` : key);
           }
         }
+      }
 
       return x as Partial<O>;
     },

--- a/src/types/partial.ts
+++ b/src/types/partial.ts
@@ -18,7 +18,7 @@ export function Part<O extends { [_: string]: Runtype }>(fields: O) {
     x => {
       if (x === null || x === undefined) {
         const a = create<any>(x, { tag: 'partial', fields });
-        throw validationError(`Expected a ${show(a)}, but was ${x}`);
+        throw validationError(`Expected ${show(a)}, but was ${x}`);
       }
 
       // tslint:disable-next-line:forin

--- a/src/types/partial.ts
+++ b/src/types/partial.ts
@@ -2,6 +2,7 @@ import { Runtype, Static, create, validationError } from '../runtype';
 import { Union } from '../index';
 import { Undefined } from './literal';
 import { hasKey } from '../util';
+import show from '../show';
 
 export interface Part<O extends { [_: string]: Runtype }>
   extends Runtype<{ [K in keyof O]?: Static<O[K]> }> {
@@ -15,16 +16,19 @@ export interface Part<O extends { [_: string]: Runtype }>
 export function Part<O extends { [_: string]: Runtype }>(fields: O) {
   return create<Part<O>>(
     x => {
-      if (x === null || x === undefined)
-        throw validationError(`Expected a defined non-null value but was ${typeof x}`);
+      if (x === null || x === undefined) {
+        const a = create<any>(x, { tag: 'partial', fields });
+        throw validationError(`Expected a ${show(a)}, but was ${x}`);
+      }
 
       // tslint:disable-next-line:forin
       for (const key in fields)
         if (hasKey(key, x)) {
+          let FieldType = Union(fields[key], Undefined);
           try {
-            Union(fields[key], Undefined).check(x[key]);
-          } catch ({ message }) {
-            throw validationError(`In key ${key}: ${message}`);
+            FieldType.check(x[key]);
+          } catch ({ message, key: nestedKey }) {
+            throw validationError(message, nestedKey ? `${key}.${nestedKey}` : key);
           }
         }
 

--- a/src/types/string.ts
+++ b/src/types/string.ts
@@ -11,7 +11,7 @@ export const String = create<String>(
   x => {
     if (typeof x !== 'string')
       throw validationError(
-        `Expected a string, but was ${x === null || x === undefined ? x : typeof x}`,
+        `Expected string, but was ${x === null || x === undefined ? x : typeof x}`,
       );
     return x;
   },

--- a/src/types/string.ts
+++ b/src/types/string.ts
@@ -9,7 +9,10 @@ export interface String extends Runtype<string> {
  */
 export const String = create<String>(
   x => {
-    if (typeof x !== 'string') throw validationError(`Expected string but was ${typeof x}`);
+    if (typeof x !== 'string')
+      throw validationError(
+        `Expected a string, but was ${x === null || x === undefined ? x : typeof x}`,
+      );
     return x;
   },
   { tag: 'string' },

--- a/src/types/tuple.ts
+++ b/src/types/tuple.ts
@@ -223,10 +223,25 @@ export function Tuple<
 export function Tuple(...components: Runtype[]): any {
   return create(
     x => {
-      const xs = Arr(Always).check(x);
+      let xs;
+
+      try {
+        xs = Arr(Always).check(x);
+      } catch ({ key, message }) {
+        throw validationError(`Expected tuple to be an array: ${message}`, key);
+      }
+
       if (xs.length < components.length)
-        throw validationError(`Expected array of ${components.length} but was ${xs.length}`);
-      for (let i = 0; i < components.length; i++) components[i].check(xs[i]);
+        throw validationError(`Expected an array of ${components.length}, but was ${xs.length}`);
+
+      for (let i = 0; i < components.length; i++) {
+        try {
+          components[i].check(xs[i]);
+        } catch ({ message, key: nestedKey }) {
+          throw validationError(message, nestedKey ? `[${i}].${nestedKey}` : `[${i}]`);
+        }
+      }
+
       return x;
     },
     { tag: 'tuple', components },

--- a/src/types/tuple.ts
+++ b/src/types/tuple.ts
@@ -232,7 +232,9 @@ export function Tuple(...components: Runtype[]): any {
       }
 
       if (xs.length < components.length)
-        throw validationError(`Expected an array of ${components.length}, but was ${xs.length}`);
+        throw validationError(
+          `Expected an array of length ${components.length}, but was ${xs.length}`,
+        );
 
       for (let i = 0; i < components.length; i++) {
         try {

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -968,7 +968,7 @@ export function Union(...alternatives: Rt[]): any {
       for (const { guard } of alternatives) if (guard(x)) return x;
 
       const a = create<any>(x as never, { tag: 'union', alternatives });
-      throw validationError(`Expected a ${show(a)}, but was ${typeof x} ${JSON.stringify(x)}`);
+      throw validationError(`Expected ${show(a)}, but was ${typeof x} ${JSON.stringify(x)}`);
     },
     { tag: 'union', alternatives, match },
   );

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -1,4 +1,5 @@
-import { Runtype as Rt, Static, create } from '../runtype';
+import { Runtype as Rt, Static, create, validationError } from '../runtype';
+import show from '../show';
 
 export interface Union1<A extends Rt> extends Rt<Static1<A>> {
   tag: 'union';
@@ -965,7 +966,9 @@ export function Union(...alternatives: Rt[]): any {
   return create(
     x => {
       for (const { guard } of alternatives) if (guard(x)) return x;
-      throw new Error('No alternatives were matched');
+
+      const a = create<any>(x as never, { tag: 'union', alternatives });
+      throw validationError(`Expected a ${show(a)}, but was ${typeof x} ${JSON.stringify(x)}`);
     },
     { tag: 'union', alternatives, match },
   );

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -968,7 +968,7 @@ export function Union(...alternatives: Rt[]): any {
       for (const { guard } of alternatives) if (guard(x)) return x;
 
       const a = create<any>(x as never, { tag: 'union', alternatives });
-      throw validationError(`Expected ${show(a)}, but was ${typeof x} ${JSON.stringify(x)}`);
+      throw validationError(`Expected ${show(a)}, but was ${typeof x}`);
     },
     { tag: 'union', alternatives, match },
   );

--- a/src/types/void.ts
+++ b/src/types/void.ts
@@ -9,7 +9,7 @@ export interface Void extends Runtype<void> {
  */
 export const Void = create<Void>(
   x => {
-    if (x !== undefined && x !== null) throw validationError(`Expected null but was ${typeof x}`);
+    if (x !== undefined && x !== null) throw validationError(`Expected null, but was ${typeof x}`);
     return x;
   },
   { tag: 'void' },


### PR DESCRIPTION
Goal was to improve the legibility of error messages, with emphasis on nested complex types.

There are things that could be improved further, for example, in union types errors from all attempts should be captured, not just the general "Expected one of ..., but was ..." as that is often super difficult to use in a debugging context (it would be much easier to understand why none of the types suited, not just the fact that none of them did).

There's also likely some room to expand the error messaging in Partial type, but this would be improved automatically with changes/improvements to Union (as it uses Union under the hood).

Some examples of the new errors

```
import { Array, String, Number, Boolean, Record } from 'runtypes';
const Flags = Array(Boolean);
Flags.check([true, true, 's']);
// { Error: Expected boolean but was string, key: '[2]' }

const Page = Record({
  title: String
});

const Person = Record({
  name: String,
  age: Number,
  likes: Array(Page)
});
const People = Array(Person);
People.check([{ name: 'Jack', likes: [] }]);
// { Error: Expected age to be number, key: '[0].age' }

People.check([{ name: 'Jack', age: 10, likes: [{ name: undefined, likes: [] }] }]);
// { Error: Expected title to be string, key: '[0].likes.[0].title' }

const Pet = Record({
  name: String
});

const PersonOrPet = Union(
  Person,
  Pet
);

PersonOrPet.check({ foo: 'bar' });
// { Error: None of the alternatives { name: string; age: number; likes: { title: string; }[]; } | { name: string; } matched {"foo":"bar"} }

const PartialPerson = Partial({
  name: String,
  age: Union(Number, String),
  likes: Array(Page)
});

PartialPerson.check({ name: 'Jack', age: { value: 10 } });
// { Error: Expected (number | string) | undefined, got {"value":10} key: 'age' }
```

There is also a bit of discussion on performance that can be seen on https://github.com/6fold/runtypes/pull/1