### PR TITLE
Added tests for Number and fixed Number.check for NaN scenario

### DIFF
--- a/src/types/number.spec.ts
+++ b/src/types/number.spec.ts
@@ -1,0 +1,24 @@
+import { Number } from '..';
+
+describe('number', () => {
+  describe('match', () => {
+    it('works', () => {
+      expect(Number.check(-1)).toEqual(-1);
+      expect(Number.check(-0)).toEqual(-0);
+      expect(Number.check(0)).toEqual(0);
+      expect(Number.check(+0)).toEqual(+0);
+      expect(Number.check(666)).toEqual(666);
+
+      expect(() => Number.check(NaN)).toThrow();
+      expect(() => Number.check(null)).toThrow();
+      expect(() => Number.check(undefined)).toThrow();
+      expect(() => Number.check(void 0)).toThrow();
+      expect(() => Number.check([])).toThrow();
+      expect(() => Number.check(true)).toThrow();
+      expect(() => Number.check(false)).toThrow();
+      expect(() => Number.check({})).toThrow();
+      expect(() => Number.check(Symbol())).toThrow();
+      expect(() => Number.check('some string')).toThrow();
+    });
+  });
+});

--- a/src/types/number.ts
+++ b/src/types/number.ts
@@ -1,4 +1,5 @@
 import { Runtype, create, validationError } from '../runtype';
+import { isNaN } from '../util';
 
 export interface Number extends Runtype<number> {
   tag: 'number';
@@ -9,9 +10,9 @@ export interface Number extends Runtype<number> {
  */
 export const Number = create<Number>(
   x => {
-    if (typeof x !== 'number')
+    if (typeof x !== 'number' || isNaN(x))
       throw validationError(
-        `Expected number, but was ${x === null || x === undefined ? x : typeof x}`,
+        `Expected number, but was ${x === null || x === undefined || isNaN(x) ? x : typeof x}`,
       );
     return x;
   },

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,3 +3,7 @@
 export function hasKey<K extends string>(k: K, o: {}): o is { [_ in K]: {} } {
   return typeof o === 'object' && k in o;
 }
+
+export function isNaN(n: any) {
+  return Number.isNaN(n);
+}


### PR DESCRIPTION
Before `Number.check(NaN)` wasn't throwing an error.