### PR TITLE
Enable Constraint to have a custom name and/or a custom static type

### DIFF
--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -29,6 +29,7 @@ export type Reflect =
       underlying: Reflect;
       constraint: ConstraintCheck<Runtype<never>>;
       args?: any;
+      name?: string;
     } & Runtype
   | { tag: 'instanceof'; ctor: Constructor<unknown> } & Runtype
   | { tag: 'brand'; brand: string; entity: Reflect } & Runtype;

--- a/src/show.ts
+++ b/src/show.ts
@@ -45,7 +45,7 @@ const show = (needsParens: boolean) => (refl: Reflect): string => {
     case 'intersect':
       return parenthesize(`${refl.intersectees.map(show(true)).join(' & ')}`);
     case 'constraint':
-      return show(needsParens)(refl.underlying);
+      return refl.name || show(needsParens)(refl.underlying);
     case 'instanceof':
       const name = (refl.ctor as any).name;
       return `InstanceOf<${name}>`;

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -1,31 +1,46 @@
 import { Runtype, Static, create } from '../runtype';
 import { String } from './string';
 import { ValidationError } from '../errors';
+import { Unknown } from './unknown';
 
 export type ConstraintCheck<A extends Runtype> = (x: Static<A>) => boolean | string;
 
-export interface Constraint<A extends Runtype, K> extends Runtype<Static<A>> {
+export interface Constraint<A extends Runtype, T extends Static<A> = Static<A>, K = unknown>
+  extends Runtype<T> {
   tag: 'constraint';
   underlying: A;
   // See: https://github.com/Microsoft/TypeScript/issues/19746 for why this isn't just
   // `constraint: ConstraintCheck<A>`
   constraint(x: Static<A>): boolean | string;
+  name?: string;
   args?: K;
 }
 
-export function Constraint<A extends Runtype, K>(
+export function Constraint<A extends Runtype, T extends Static<A> = Static<A>, K = unknown>(
   underlying: A,
   constraint: ConstraintCheck<A>,
-  args?: K,
-) {
-  return create<Constraint<A, K>>(
+  options?: { name?: string; args?: K },
+): Constraint<A, T, K> {
+  return create<Constraint<A, T, K>>(
     x => {
+      const name = options && options.name;
       const typed = underlying.check(x);
       const result = constraint(typed);
       if (String.guard(result)) throw new ValidationError(result);
-      else if (!result) throw new ValidationError('Failed constraint check');
-      return typed;
+      else if (!result) throw new ValidationError(`Failed ${name || 'constraint'} check`);
+      return (typed as unknown) as T;
     },
-    { tag: 'constraint', underlying, args, constraint },
+    {
+      tag: 'constraint',
+      underlying,
+      constraint,
+      name: options && options.name,
+      args: options && options.args,
+    },
   );
 }
+
+export const Guard = <T, K = unknown>(
+  guard: (x: unknown) => x is T,
+  options?: { name?: string; args?: K },
+) => Unknown.withGuard(guard, options);


### PR DESCRIPTION
_EDIT: this PR changed a lot, and got more general, so this initial post is not where the solution is heading. See discussion below._

This PR adds an optional parameter `customInstanceOf?: (o: V) => boolean` to the `InstanceOf` constructor. This parameter lets clients optionally use a custom function instead of the default `instanceof` keyword to decide if an object is an instance of the specified class.

**Justification** 

This is helpful in cases where multiple library versions might be running side-by-side in the same process. This is unfortunately common in a node.js environment, e.g. you depend on library A and library B which each depend on different versions of library C.

Usually libraries which want to run side-by-side will have a static `isXXX` method as a version-safe alternative to `instanceof`.   Examples:
* [`Buffer.isBuffer`](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_isbuffer_obj) - from Node.js API
* [`ObjectId.isValid`](https://github.com/mongodb/js-bson/blob/7bb9c57db1c5f862dee4762fd2211e2a722cb75d/lib/objectid.js#L320) - from MongoDB client API for Node.js

These isXXX functions are usually implemented via checking a special property (e.g. `_bsontype` for some classes in the MongoDB client library) that's used for the purpose of identifying instances of the same class across versions.  So even if a library doesn't offer an isXXX function, the client can easily build one and pass it to the `customInstanceOf` parameter in this PR.

**Tests**

I added tests for this PR that: 
1. Create two different versions of the same class and verifying that a custom isXXX function will cause `check()` to return `true` when comparing instances of different versions.  Existing tests with the default `instanceof` behavior still pass.
2. Add `InstanceOf` tests for `Date` and `RegExp` objects. This is unrelated to this PR but those two built-in classes are (in my experience) frequent sources of class-related validation bugs so it's good to have them tested!

BTW, this library seems great. I'm in the middle of converting my app over to use it, and so far the only serious gap I've found is here in this PR. If you want me to change anything about this PR, I'm happy to do it-- just let me know. Thanks!