### PR TITLE
fix: remove TS 3.5.1 compiler errors

### DIFF
--- a/src/types/partial.ts
+++ b/src/types/partial.ts
@@ -16,7 +16,7 @@ export function Part<O extends { [_: string]: Runtype }>(fields: O) {
   return create<Part<O>>(
     x => {
       if (x === null || x === undefined) {
-        const a = create<any>(x, { tag: 'partial', fields });
+        const a = create<any>(x => x, { tag: 'partial', fields });
         throw new ValidationError(`Expected ${show(a)}, but was ${x}`);
       }
 

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -27,7 +27,7 @@ export function InternalRecord<O extends { [_: string]: Runtype }, RO extends bo
     create(
       x => {
         if (x === null || x === undefined) {
-          const a = create<any>(x, { tag: 'record', fields });
+          const a = create<any>(x => x, { tag: 'record', fields });
           throw new ValidationError(`Expected ${show(a)}, but was ${x}`);
         }
 

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -8,13 +8,14 @@ export interface Union1<A extends Rt> extends Rt<Static<A>> {
   match: Match1<A>;
 }
 
-export interface Union2<A extends Rt, B extends Rt> extends Rt<Static<A | B>> {
+export interface Union2<A extends Rt, B extends Rt> extends Rt<Static<A> | Static<B>> {
   tag: 'union';
   alternatives: [A, B];
   match: Match2<A, B>;
 }
 
-export interface Union3<A extends Rt, B extends Rt, C extends Rt> extends Rt<Static<A | B | C>> {
+export interface Union3<A extends Rt, B extends Rt, C extends Rt>
+  extends Rt<Static<A> | Static<B> | Static<C>> {
   tag: 'union';
   alternatives: [A, B, C];
   match: Match3<A, B, C>;
@@ -1475,13 +1476,15 @@ export interface Match20<
 export type Case<T extends Rt, Result> = (v: Static<T>) => Result;
 
 export type Matcher1<A extends Rt, Z> = (x: Static<A>) => Z;
-export type Matcher2<A extends Rt, B extends Rt, Z> = (x: Static<A | B>) => Z;
-export type Matcher3<A extends Rt, B extends Rt, C extends Rt, Z> = (x: Static<A | B | C>) => Z;
+export type Matcher2<A extends Rt, B extends Rt, Z> = (x: Static<A> | Static<B>) => Z;
+export type Matcher3<A extends Rt, B extends Rt, C extends Rt, Z> = (
+  x: Static<A> | Static<B> | Static<C>,
+) => Z;
 export type Matcher4<A extends Rt, B extends Rt, C extends Rt, D extends Rt, Z> = (
-  x: Static<A | B | C | D>,
+  x: Static<A> | Static<B> | Static<C> | Static<D>,
 ) => Z;
 export type Matcher5<A extends Rt, B extends Rt, C extends Rt, D extends Rt, E extends Rt, Z> = (
-  x: Static<A | B | C | D | E>,
+  x: Static<A> | Static<B> | Static<C> | Static<D> | Static<E>,
 ) => Z;
 export type Matcher6<
   A extends Rt,
@@ -1491,7 +1494,7 @@ export type Matcher6<
   E extends Rt,
   F extends Rt,
   Z
-> = (x: Static<A | B | C | D | E | F>) => Z;
+> = (x: Static<A> | Static<B> | Static<C> | Static<D> | Static<E> | Static<F>) => Z;
 export type Matcher7<
   A extends Rt,
   B extends Rt,
@@ -1501,7 +1504,7 @@ export type Matcher7<
   F extends Rt,
   G extends Rt,
   Z
-> = (x: Static<A | B | C | D | E | F | G>) => Z;
+> = (x: Static<A> | Static<B> | Static<C> | Static<D> | Static<E> | Static<F> | Static<G>) => Z;
 export type Matcher8<
   A extends Rt,
   B extends Rt,
@@ -1512,7 +1515,9 @@ export type Matcher8<
   G extends Rt,
   H extends Rt,
   Z
-> = (x: Static<A | B | C | D | E | F | G | H>) => Z;
+> = (
+  x: Static<A> | Static<B> | Static<C> | Static<D> | Static<E> | Static<F> | Static<G> | Static<H>,
+) => Z;
 export type Matcher9<
   A extends Rt,
   B extends Rt,
@@ -1524,7 +1529,18 @@ export type Matcher9<
   H extends Rt,
   I extends Rt,
   Z
-> = (x: Static<A | B | C | D | E | F | G | H | I>) => Z;
+> = (
+  x:
+    | Static<A>
+    | Static<B>
+    | Static<C>
+    | Static<D>
+    | Static<E>
+    | Static<F>
+    | Static<G>
+    | Static<H>
+    | Static<I>,
+) => Z;
 export type Matcher10<
   A extends Rt,
   B extends Rt,
@@ -1537,7 +1553,19 @@ export type Matcher10<
   I extends Rt,
   J extends Rt,
   Z
-> = (x: Static<A | B | C | D | E | F | G | H | I | J>) => Z;
+> = (
+  x:
+    | Static<A>
+    | Static<B>
+    | Static<C>
+    | Static<D>
+    | Static<E>
+    | Static<F>
+    | Static<G>
+    | Static<H>
+    | Static<I>
+    | Static<J>,
+) => Z;
 export type Matcher11<
   A extends Rt,
   B extends Rt,
@@ -1551,7 +1579,20 @@ export type Matcher11<
   J extends Rt,
   K extends Rt,
   Z
-> = (x: Static<A | B | C | D | E | F | G | H | I | J | K>) => Z;
+> = (
+  x:
+    | Static<A>
+    | Static<B>
+    | Static<C>
+    | Static<D>
+    | Static<E>
+    | Static<F>
+    | Static<G>
+    | Static<H>
+    | Static<I>
+    | Static<J>
+    | Static<K>,
+) => Z;
 export type Matcher12<
   A extends Rt,
   B extends Rt,
@@ -1566,7 +1607,21 @@ export type Matcher12<
   K extends Rt,
   L extends Rt,
   Z
-> = (x: Static<A | B | C | D | E | F | G | H | I | J | K | L>) => Z;
+> = (
+  x:
+    | Static<A>
+    | Static<B>
+    | Static<C>
+    | Static<D>
+    | Static<E>
+    | Static<F>
+    | Static<G>
+    | Static<H>
+    | Static<I>
+    | Static<J>
+    | Static<K>
+    | Static<L>,
+) => Z;
 export type Matcher13<
   A extends Rt,
   B extends Rt,
@@ -1582,7 +1637,22 @@ export type Matcher13<
   L extends Rt,
   M extends Rt,
   Z
-> = (x: Static<A | B | C | D | E | F | G | H | I | J | K | L | M>) => Z;
+> = (
+  x:
+    | Static<A>
+    | Static<B>
+    | Static<C>
+    | Static<D>
+    | Static<E>
+    | Static<F>
+    | Static<G>
+    | Static<H>
+    | Static<I>
+    | Static<J>
+    | Static<K>
+    | Static<L>
+    | Static<M>,
+) => Z;
 export type Matcher14<
   A extends Rt,
   B extends Rt,
@@ -1599,7 +1669,23 @@ export type Matcher14<
   M extends Rt,
   N extends Rt,
   Z
-> = (x: Static<A | B | C | D | E | F | G | H | I | J | K | L | M | N>) => Z;
+> = (
+  x:
+    | Static<A>
+    | Static<B>
+    | Static<C>
+    | Static<D>
+    | Static<E>
+    | Static<F>
+    | Static<G>
+    | Static<H>
+    | Static<I>
+    | Static<J>
+    | Static<K>
+    | Static<L>
+    | Static<M>
+    | Static<N>,
+) => Z;
 export type Matcher15<
   A extends Rt,
   B extends Rt,
@@ -1617,7 +1703,24 @@ export type Matcher15<
   N extends Rt,
   O extends Rt,
   Z
-> = (x: Static<A | B | C | D | E | F | G | H | I | J | K | L | M | N | O>) => Z;
+> = (
+  x:
+    | Static<A>
+    | Static<B>
+    | Static<C>
+    | Static<D>
+    | Static<E>
+    | Static<F>
+    | Static<G>
+    | Static<H>
+    | Static<I>
+    | Static<J>
+    | Static<K>
+    | Static<L>
+    | Static<M>
+    | Static<N>
+    | Static<O>,
+) => Z;
 export type Matcher16<
   A extends Rt,
   B extends Rt,
@@ -1636,7 +1739,25 @@ export type Matcher16<
   O extends Rt,
   P extends Rt,
   Z
-> = (x: Static<A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P>) => Z;
+> = (
+  x:
+    | Static<A>
+    | Static<B>
+    | Static<C>
+    | Static<D>
+    | Static<E>
+    | Static<F>
+    | Static<G>
+    | Static<H>
+    | Static<I>
+    | Static<J>
+    | Static<K>
+    | Static<L>
+    | Static<M>
+    | Static<N>
+    | Static<O>
+    | Static<P>,
+) => Z;
 export type Matcher17<
   A extends Rt,
   B extends Rt,
@@ -1656,7 +1777,26 @@ export type Matcher17<
   P extends Rt,
   Q extends Rt,
   Z
-> = (x: Static<A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q>) => Z;
+> = (
+  x:
+    | Static<A>
+    | Static<B>
+    | Static<C>
+    | Static<D>
+    | Static<E>
+    | Static<F>
+    | Static<G>
+    | Static<H>
+    | Static<I>
+    | Static<J>
+    | Static<K>
+    | Static<L>
+    | Static<M>
+    | Static<N>
+    | Static<O>
+    | Static<P>
+    | Static<Q>,
+) => Z;
 export type Matcher18<
   A extends Rt,
   B extends Rt,
@@ -1677,7 +1817,27 @@ export type Matcher18<
   Q extends Rt,
   R extends Rt,
   Z
-> = (x: Static<A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R>) => Z;
+> = (
+  x:
+    | Static<A>
+    | Static<B>
+    | Static<C>
+    | Static<D>
+    | Static<E>
+    | Static<F>
+    | Static<G>
+    | Static<H>
+    | Static<I>
+    | Static<J>
+    | Static<K>
+    | Static<L>
+    | Static<M>
+    | Static<N>
+    | Static<O>
+    | Static<P>
+    | Static<Q>
+    | Static<R>,
+) => Z;
 export type Matcher19<
   A extends Rt,
   B extends Rt,
@@ -1699,7 +1859,28 @@ export type Matcher19<
   R extends Rt,
   S extends Rt,
   Z
-> = (x: Static<A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S>) => Z;
+> = (
+  x:
+    | Static<A>
+    | Static<B>
+    | Static<C>
+    | Static<D>
+    | Static<E>
+    | Static<F>
+    | Static<G>
+    | Static<H>
+    | Static<I>
+    | Static<J>
+    | Static<K>
+    | Static<L>
+    | Static<M>
+    | Static<N>
+    | Static<O>
+    | Static<P>
+    | Static<Q>
+    | Static<R>
+    | Static<S>,
+) => Z;
 export type Matcher20<
   A extends Rt,
   B extends Rt,
@@ -1722,4 +1903,26 @@ export type Matcher20<
   S extends Rt,
   T extends Rt,
   Z
-> = (x: Static<A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P | Q | R | S | T>) => Z;
+> = (
+  x:
+    | Static<A>
+    | Static<B>
+    | Static<C>
+    | Static<D>
+    | Static<E>
+    | Static<F>
+    | Static<G>
+    | Static<H>
+    | Static<I>
+    | Static<J>
+    | Static<K>
+    | Static<L>
+    | Static<M>
+    | Static<N>
+    | Static<O>
+    | Static<P>
+    | Static<Q>
+    | Static<R>
+    | Static<S>
+    | Static<T>,
+) => Z;


### PR DESCRIPTION
Fixes #89. This PR addresses compiler errors when runtypes is compiled using TypeScript 3.5.1. There are 100+ compiler errors when building the runtypes library, but only two root causes. 

Two of the errors are legit type bugs in runtypes code, where we were passing `undefined` or `null` as the first param of the `create()` function, when it should have been a function that returned `undefined` or `null`. 

The rest of the errors are caused by https://github.com/microsoft/TypeScript/issues/31731.  I don't think this is a deliberate breaking change on TS's part. I suspect it's a bug.

Luckily there's an easy workaround we can use to fix runtypes without waiting for TS to fix it.  The problem is in union.ts where we currently declare types like this:  
```ts
export interface Union2<A extends Rt, B extends Rt> extends Rt<Static<A | B>> {
```

To work around that TS issue linked above, the trick is to split up the union, so instead of `Static<A | B>` we should use `Static<A> | Static<B>`.

```ts
export interface Union2<A extends Rt, B extends Rt> extends Rt<Static<A> | Static<B>> {
```

This PR implements this trick throughout union.ts. 