### PR TITLE
Add key to validation Failure Result

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -26,6 +26,11 @@ export type Failure = {
    * A message indicating the reason validation failed.
    */
   message: string;
+
+  /**
+   * A key indicating the location at which validation failed.
+   */
+  key: string;
 };
 
 /**

--- a/src/result.ts
+++ b/src/result.ts
@@ -30,7 +30,7 @@ export type Failure = {
   /**
    * A key indicating the location at which validation failed.
    */
-  key: string;
+  key?: string;
 };
 
 /**

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -116,8 +116,8 @@ export function create<A extends Runtype>(check: (x: {}) => Static<A>, A: any): 
     try {
       check(value);
       return { success: true, value };
-    } catch ({ message }) {
-      return { success: false, message };
+    } catch ({ message, key }) {
+      return { success: false, message, key };
     }
   }
 


### PR DESCRIPTION
It looks like `check` returns the key at which the type checking failed, so it was helpful (for my own uses) to have `validate` do the same. This way, user feedback with `validate` can be more specific and helpful.