### PR TITLE
Remove reflect-metadata dependency and simplify decorator code

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,5 @@
     },
     "testEnvironment": "node"
   },
-  "dependencies": {
-    "reflect-metadata": "^0.1.13"
-  }
+  "dependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2850,11 +2850,6 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-reflect-metadata@^0.1.13:
-  version "0.1.13"
-  resolved "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
-  integrity sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==
-
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"


### PR DESCRIPTION
As noted in #100, the use of `reflect-metadata` is a heavy dependency (due to its use of globals and `object` prototype pollution, and the fact that it is not yet on a standards track and likely to change).

The code wasn't using its power anyway, so I've swapped it out for a `WeakMap` performing the same role. I also tidied up some of the duplicate code and fixed a small mistake in the documentation while I was in the file.

All tests continue to pass, and I have run `yarn format`.