### PR TITLE
Added failed key to error message

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,7 +2,7 @@ export class ValidationError extends Error {
   public name: string = 'ValidationError';
 
   constructor(public message: string, public key?: string) {
-    super(message);
+    super(key ? `${message} in ${key}` : message);
 
     Object.setPrototypeOf(this, ValidationError.prototype);
   }


### PR DESCRIPTION
Now it's absolutely unclear how to find an error when `.check` has failed.
This way errors will look like this `Expected string, but was number in nested.arr.[0]`.
I believe it's not breaking and for user convenience only.