### PR TITLE
Add Struct and Maybe types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,3 +26,5 @@ export * from './types/lazy';
 export * from './types/constraint';
 export { Brand } from './types/brand';
 export * from './decorator';
+export * from './types/maybe';
+export * from './types/struct';

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -17,12 +17,14 @@ export type Reflect =
       { readonly [_ in string]: unknown }
     >)
   | ({ tag: 'partial'; fields: { [_: string]: Reflect } } & Runtype<{ [_ in string]?: unknown }>)
+  | ({ tag: 'struct'; fields: { [_: string]: Reflect } } & Runtype<{ [_ in string]?: unknown }>)
   | ({ tag: 'dictionary'; key: 'string' | 'number'; value: Reflect } & Runtype<{
       [_: string]: unknown;
     }>)
   | ({ tag: 'tuple'; components: Reflect[] } & Runtype<unknown[]>)
   | ({ tag: 'union'; alternatives: Reflect[] } & Runtype)
   | ({ tag: 'intersect'; intersectees: Reflect[] } & Runtype)
+  | ({ tag: 'maybe'; type: Reflect } & Runtype)
   | ({ tag: 'function' } & Runtype<(...args: any[]) => any>)
   | ({
       tag: 'constraint';

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -29,6 +29,12 @@ export interface Runtype<A = unknown> {
   check(x: any): A;
 
   /**
+   * Verifies that a value conforms to this runtype. If so, returns the same value,
+   * statically typed. Otherwise throws an exception.
+   */
+  eval<T extends Runtype<A>>(a: Static<T>): Static<T>;
+
+  /**
    * Validates that a value conforms to this type, and returns a result indicating
    * success or failure (does not throw).
    */
@@ -110,6 +116,7 @@ export function create<A extends Runtype>(
   A: any,
 ): A {
   A.check = check;
+  A.eval = check;
   A.assert = check;
   A._innerValidate = (value: any, visited: VisitedState) => {
     if (visited.has(value, A)) return { success: true, value };

--- a/src/show.spec.ts
+++ b/src/show.spec.ts
@@ -20,6 +20,8 @@ import {
   Lazy,
   InstanceOf,
   Reflect,
+  Maybe,
+  Struct,
 } from '.';
 import show from './show';
 
@@ -74,6 +76,8 @@ const cases: [Reflect, string][] = [
   [Boolean.And(Number.Or(String)), 'boolean & (number | string)'],
   [Boolean.Or(Number.And(String)), 'boolean | (number & string)'],
   [Boolean.Or(Record({ x: String, y: Number })), 'boolean | { x: string; y: number; }'],
+  [Maybe(Boolean), 'Maybe<boolean>'],
+  [Struct({ x: String, y: Number }), '{ x: string; y: number; }'],
 ];
 
 for (const [T, expected] of cases) {

--- a/src/show.ts
+++ b/src/show.ts
@@ -45,12 +45,20 @@ const show = (needsParens: boolean, circular: Set<Reflect>) => (refl: Reflect): 
           ? `{ ${keys.map(k => `${k}?: ${show(false, circular)(refl.fields[k])};`).join(' ')} }`
           : '{}';
       }
+      case 'struct': {
+        const keys = Object.keys(refl.fields);
+        return keys.length
+          ? `{ ${keys.map(k => `${k}: ${show(false, circular)(refl.fields[k])};`).join(' ')} }`
+          : '{}';
+      }
       case 'tuple':
         return `[${refl.components.map(show(false, circular)).join(', ')}]`;
       case 'union':
         return parenthesize(`${refl.alternatives.map(show(true, circular)).join(' | ')}`);
       case 'intersect':
         return parenthesize(`${refl.intersectees.map(show(true, circular)).join(' & ')}`);
+      case 'maybe':
+        return `Maybe<${show(true, circular)(refl.type)}>`;
       case 'constraint':
         return refl.name || show(needsParens, circular)(refl.underlying);
       case 'instanceof':

--- a/src/types/maybe.ts
+++ b/src/types/maybe.ts
@@ -1,0 +1,18 @@
+import { Runtype, Static } from '../runtype';
+import { Union } from './union';
+import { Undefined } from './literal';
+
+export interface Maybe<A extends Runtype> extends Runtype<Static<A> | undefined> {
+  tag: 'maybe';
+  type: A;
+}
+
+/**
+ * Construct a runtype for maybe values
+ */
+export const Maybe = <T extends Runtype>(type: T): Maybe<T> => {
+  const base = (Union(Undefined, type) as unknown) as Maybe<T>;
+  base.type = type;
+  base.tag = 'maybe';
+  return base;
+};

--- a/src/types/struct.ts
+++ b/src/types/struct.ts
@@ -1,0 +1,57 @@
+import { Runtype, Static } from '../runtype';
+import { Maybe } from './maybe';
+import { Record as _Record } from './record';
+import { Partial as _Partial } from './partial';
+
+type RuntypeDict = { [_: string]: Runtype };
+
+type RequiredPropertyNames<T extends RuntypeDict> = {
+  [K in keyof T]: T[K] extends Maybe<any> ? never : K;
+}[keyof T];
+
+type OptionalPropertyNames<T extends RuntypeDict> = {
+  [K in keyof T]: T[K] extends Maybe<any> ? K : never;
+}[keyof T];
+
+type RequiredPropertyValues<T extends RuntypeDict> = {
+  [K in keyof T]: T[K] extends Maybe<any> ? never : Static<T[K]>;
+};
+
+type OptionalPropertyValues<T extends RuntypeDict> = {
+  [K in keyof T]: T[K] extends Maybe<any> ? Static<T[K]> : never;
+};
+
+export interface Struct<O extends RuntypeDict>
+  extends Runtype<
+    { [P in RequiredPropertyNames<O>]: RequiredPropertyValues<O>[P] } &
+      { [P in OptionalPropertyNames<O>]?: OptionalPropertyValues<O>[P] }
+  > {
+  tag: 'struct';
+  fields: O;
+}
+
+/**
+ * Construct a struct runtype from runtypes for its values.
+ */
+export function Struct<O extends RuntypeDict>(fields: O): Struct<O> {
+  const required: any = {};
+  const optional: any = {};
+  let withOptional = false;
+  Object.keys(fields).forEach(key => {
+    const rt = fields[key];
+    if ((rt as any).tag === 'maybe') {
+      optional[key] = rt;
+      withOptional = true;
+    } else {
+      required[key] = rt;
+    }
+  });
+
+  let base: Struct<O> = _Record(required) as any;
+  if (withOptional) {
+    base = base.And(_Partial(optional)) as any;
+  }
+  base.fields = fields;
+  base.tag = 'struct';
+  return base;
+}


### PR DESCRIPTION
`Struct` is an extension of `Record` that sets optional properties of `Maybe` type.

```ts
const User = Struct({
  id: Maybe(Number),
  name: String,
})
```

Equivalences:

`Maybe(T)` == `Union(T, Undefined)`
`Struct({ opt: Maybe(O), req: R })` == `Record({ req: R }).And(Partial({ opt: O }))`

Additionally the `eval` utility does the same that `check` but also check types at compile time.
```ts
const user = User.eval({
  id: 'invalid'
})

// Error...
```

