### PR TITLE
Make format.js work on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# TypeScript files will always have LF line endings on checkout,
+# so that running 'yarn format' on Windows will not need to change
+# line endings from CRLF to LF causing git to report modified files
+# with no code changes.
+*.ts text eol=lf

--- a/scripts/format.js
+++ b/scripts/format.js
@@ -7,10 +7,15 @@ process.on('unhandledRejection', err => {
   throw err;
 });
 
-const { exec } = require('child_process');
+const { exec, execSync } = require('child_process');
+const { join } = require('path');
+
+const npmBinPath = execSync('npm bin')
+  .toString()
+  .trim();
 
 const command = [
-  '$(npm bin)/prettier',
+  join(npmBinPath, 'prettier'),
   process.env.CI ? '--list-different' : '--write',
   '"./**/*.{ts,tsx,js,json,css}"',
 ];


### PR DESCRIPTION
The fix uses `execSync` to get the path output from `npm bin` rather than embedding the Bash-specific `$(npm bin)` in the command. I tested it successfully on Windows 10 and Ubuntu.