### PR TITLE
Fix for error TS2349

### DIFF
--- a/src/show.ts
+++ b/src/show.ts
@@ -58,11 +58,12 @@ const show = (needsParens: boolean, circular: Set<Reflect>) => (refl: Reflect): 
         return `InstanceOf<${name}>`;
       case 'brand':
         return show(needsParens, circular)(refl.entity);
+      default:
+        throw Error('impossible');
     }
   } finally {
     circular.delete(refl);
   }
-  throw Error('impossible');
 };
 
 export default show(false, new Set<Reflect>());


### PR DESCRIPTION
```
error TS2349: This expression is not callable.
  Type 'never' has no call signatures.

► http://localhost:8000/raw.githubusercontent.com/pelotom/runtypes/master/src/show.ts:65:9

65   throw Error('impossible');
           ~~~~~
```