### PR TITLE
Implement Discriminated Unions

### DIFF
--- a/src/types/union.spec.ts
+++ b/src/types/union.spec.ts
@@ -1,4 +1,4 @@
-import { Union, String, Literal } from '..';
+import { Union, String, Literal, Record, Number, InstanceOf } from '..';
 
 const ThreeOrString = Union(Literal(3), String);
 
@@ -11,6 +11,52 @@ describe('union', () => {
       );
       expect(match(3)).toBe(8);
       expect(match('hello')).toBe(20);
+    });
+  });
+
+  describe('discriminated union', () => {
+    it('should pick correct alternative with typescript docs example', () => {
+      const Square = Record({ kind: Literal('square'), size: Number });
+      const Rectangle = Record({ kind: Literal('rectangle'), width: Number, height: Number });
+      const Circle = Record({ kind: Literal('circle'), radius: Number });
+
+      const Shape = Union(Square, Rectangle, Circle);
+
+      expect(Shape.validate({ kind: 'square', size: new Date() })).toMatchObject({
+        success: false,
+        key: 'size',
+      });
+
+      expect(Shape.validate({ kind: 'rectangle', size: new Date() })).toMatchObject({
+        success: false,
+        key: 'width',
+      });
+
+      expect(Shape.validate({ kind: 'circle', size: new Date() })).toMatchObject({
+        success: false,
+        key: 'radius',
+      });
+
+      expect(Shape.validate({ kind: 'other', size: new Date() })).not.toHaveProperty('key');
+    });
+
+    it('hould not pick alternative if the discriminant is not unique', () => {
+      const Square = Record({ kind: Literal('square'), size: Number });
+      const Rectangle = Record({ kind: Literal('rectangle'), width: Number, height: Number });
+      const CircularSquare = Record({ kind: Literal('square'), radius: Number });
+
+      const Shape = Union(Square, Rectangle, CircularSquare);
+
+      expect(Shape.validate({ kind: 'square', size: new Date() })).not.toHaveProperty('key');
+    });
+
+    it('should not pick alternative if not all types are records', () => {
+      const Square = Record({ kind: Literal('square'), size: Number });
+      const Rectangle = Record({ kind: Literal('rectangle'), width: Number, height: Number });
+
+      const Shape = Union(Square, Rectangle, InstanceOf(Date));
+
+      expect(Shape.validate({ kind: 'square', size: new Date() })).not.toHaveProperty('key');
     });
   });
 });

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -968,40 +968,35 @@ export function Union(...alternatives: Rt[]): any {
 
   return create(
     (value, visited) => {
-      if (
-        alternatives.length > 1 &&
-        alternatives.every(alternative => alternative.reflect.tag === 'record')
-      ) {
-        const commonLiteralFields: { [key: string]: LiteralBase[] } = {};
-        for (const alternative of alternatives) {
-          if (alternative.reflect.tag === 'record') {
-            for (const fieldName in alternative.reflect.fields) {
-              const field = alternative.reflect.fields[fieldName];
-              if (field.tag === 'literal') {
-                if (commonLiteralFields[fieldName]) {
-                  if (commonLiteralFields[fieldName].every(value => value !== field.value)) {
-                    commonLiteralFields[fieldName].push(field.value);
-                  }
-                } else {
-                  commonLiteralFields[fieldName] = [field.value];
+      const commonLiteralFields: { [key: string]: LiteralBase[] } = {};
+      for (const alternative of alternatives) {
+        if (alternative.reflect.tag === 'record') {
+          for (const fieldName in alternative.reflect.fields) {
+            const field = alternative.reflect.fields[fieldName];
+            if (field.tag === 'literal') {
+              if (commonLiteralFields[fieldName]) {
+                if (commonLiteralFields[fieldName].every(value => value !== field.value)) {
+                  commonLiteralFields[fieldName].push(field.value);
                 }
+              } else {
+                commonLiteralFields[fieldName] = [field.value];
               }
             }
           }
         }
+      }
 
-        for (const fieldName in commonLiteralFields) {
-          if (commonLiteralFields[fieldName].length === alternatives.length) {
-            for (const alternative of alternatives) {
-              if (alternative.reflect.tag === 'record') {
-                const field = alternative.reflect.fields[fieldName];
-                if (
-                  field.tag === 'literal' &&
-                  hasKey(fieldName, value) &&
-                  value[fieldName] === field.value
-                ) {
-                  return innerValidate(alternative, value, visited);
-                }
+      for (const fieldName in commonLiteralFields) {
+        if (commonLiteralFields[fieldName].length === alternatives.length) {
+          for (const alternative of alternatives) {
+            if (alternative.reflect.tag === 'record') {
+              const field = alternative.reflect.fields[fieldName];
+              if (
+                field.tag === 'literal' &&
+                hasKey(fieldName, value) &&
+                value[fieldName] === field.value
+              ) {
+                return innerValidate(alternative, value, visited);
               }
             }
           }


### PR DESCRIPTION
First of all, AWESOME library! One thing has been bugging me about it though and its support for Discriminated Unions.

This is my attempt on addressing it, and I've seen similar issues being raised too.

So with this PR, when those conditions are met:
- all the alternatives of a union are records
- they have at least one field in common, that is a literal in each
record with unique values

Then when checking the alternatives we can pick the correct one first, and then perform the validation, thus producing more specific error messages.

This is something already present in TypeScript itself https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions and seems to have been requested before https://github.com/pelotom/runtypes/issues/67 .
Though this implementation would not work in all the cases covered by TS, but it's a start.

I'll be glad to add more tests or work on the implementation on your direction. Sorry for the long implementation, but the you seem to be supporting way older version of JS than I'm used to so had to implement the logic in for loops and such.