### PR TITLE
Export InternamRecord

### DIFF
--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -14,7 +14,7 @@ type RecordStaticType<
   ? { readonly [K in keyof O]: Static<O[K]> }
   : { [K in keyof O]: Static<O[K]> };
 
-interface InternalRecord<
+export interface InternalRecord<
   O extends { [_: string]: Runtype },
   Part extends boolean,
   RO extends boolean
@@ -43,7 +43,7 @@ export type Partial<O extends { [_: string]: Runtype }, RO extends boolean> = In
 /**
  * Construct a record runtype from runtypes for its values.
  */
-function InternalRecord<
+export function InternalRecord<
   O extends { [_: string]: Runtype },
   Part extends boolean,
   RO extends boolean


### PR DESCRIPTION
This is my fault, since the lib built and tested fine I thought maybe it
was okay to leave out the exports. This change just restores the things
that were formerly exported.

When you install 5.0, you will get compile errors like

```
Exported variable 'Foo' has or is using name 'InternalRecord' from external module ".../node_modules/runtypes/lib/types/record" but cannot be named.
```

if you use `Record`.