### PR TITLE
Passing null to Union(...).guard throws in some cases

### DIFF
--- a/src/types/union.spec.ts
+++ b/src/types/union.spec.ts
@@ -40,7 +40,7 @@ describe('union', () => {
       expect(Shape.validate({ kind: 'other', size: new Date() })).not.toHaveProperty('key');
     });
 
-    it('hould not pick alternative if the discriminant is not unique', () => {
+    it('should not pick alternative if the discriminant is not unique', () => {
       const Square = Record({ kind: Literal('square'), size: Number });
       const Rectangle = Record({ kind: Literal('rectangle'), width: Number, height: Number });
       const CircularSquare = Record({ kind: Literal('square'), radius: Number });
@@ -57,6 +57,34 @@ describe('union', () => {
       const Shape = Union(Square, Rectangle, InstanceOf(Date));
 
       expect(Shape.validate({ kind: 'square', size: new Date() })).not.toHaveProperty('key');
+    });
+
+    it('should not break when null is passed to (discriminated) Union.guard', () => {
+      const Square = Record({ kind: Literal('square'), size: Number });
+      const Rectangle = Record({ kind: Literal('rectangle'), width: Number, height: Number });
+      const CircularSquare = Record({ kind: Literal('square'), radius: Number });
+
+      const Shape = Union(Square, Rectangle, CircularSquare);
+
+      // Passes
+      expect(Shape.guard(null)).toBe(false);
+    });
+
+    it('should not break when null is passed to (discriminated) Union.guard 2', () => {
+      const DiscriminatedUnion = Union(
+        Record({ kind: Literal('foo'), size: Number }),
+        Record({ kind: Literal('bar'), foo: String }),
+      );
+
+      expect(DiscriminatedUnion.guard(null)).toBe(false);
+    });
+
+    it('should not break when null is passed to (discriminated) Union.guard 3', () => {
+      const A = Record({ kind: Literal('a') });
+      const B = Record({ kind: Literal('b') });
+      const DiscriminatedUnion = Union(A, B);
+
+      expect(DiscriminatedUnion.guard(null)).toBe(false);
     });
   });
 });

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -993,6 +993,7 @@ export function Union(...alternatives: Rt[]): any {
               const field = alternative.reflect.fields[fieldName];
               if (
                 field.tag === 'literal' &&
+                value !== null &&
                 hasKey(fieldName, value) &&
                 value[fieldName] === field.value
               ) {


### PR DESCRIPTION
I'm not sure at all why, and the test with the types copied from above
passes, so I'm pretty confused.  I don't have time to debug it right
now, but these cause:

```
TypeError: Cannot use 'in' operator to search for 'kind' in null
```

And here's the backtrace for reference:

```
at Object.hasKey (src/util.ts:4:36)
at Union.runtype_1.create.tag (src/types/union.ts:996:17)
at Object.A._innerValidate (src/runtype.ts:116:12)
at Object.A.validate (src/runtype.ts:118:34)
at Object.guard (src/runtype.ts:139:14)
at Object.<anonymous> (src/types/union.spec.ts:87:33)
```

Am I doing something dumb or missing something obvious?  I can't see a
real difference between the passing case and the failing ones.