### PR TITLE
feat: add `Transform`

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,47 @@ const B = Guard(Buffer.isBuffer);
 type T = Static<typeof B>; // T will have type of `Buffer`
 ```
 
+## Transforms
+
+Sometimes we want to convert values along with validation, for example:
+
+- Populate properties of more descriptive object with a shorthand value
+- Deserialize incoming data into hydrated object, e.g. timestamp `number` to `Date`
+- Maintain backward compatibility upgrading old input into new representation
+
+We have a Swiss Army knife for such situations, called `Transform`. Usually you
+want to use it through `withTransform` method of a `Runtype`:
+
+```ts
+const ParsedInt = String.withTransform(s => {
+  const parsed = parseInt(s);
+  if (isNaN(parsed)) throw new Error('Parse failed');
+  else return parsed;
+});
+```
+
+Errors thrown by transformer functions are gracefully caught by the underlying
+`Runtype` and treated as validation errors like usual:
+
+```ts
+if (ParsedInt.guard('crap')) return 'Never reach here';
+else return 'Always reach here';
+
+ParsedInt.check('crap');
+// ValidationError: Failed transform: Error: Parse failed
+```
+
+`Static` should work as expected:
+
+```ts
+type ParsedInt = Static<typeof ParsedInt>;
+// Above type is inferred as: `number`
+```
+
+Maybe you've noticed that `Transform` actually covers the same functionalities
+of `Constraint` and `Guard`, but it's not recommended using `Transform`s without
+any transformation of values, simply because it makes your code look nonsense.
+
 ## Function contracts
 
 Runtypes along with constraint checking are a natural fit for enforcing function

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,5 +23,6 @@ export * from './types/function';
 export { InstanceOf } from './types/instanceof';
 export * from './types/lazy';
 export * from './types/constraint';
+export * from './types/transform';
 export { Brand } from './types/brand';
 export * from './decorator';

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -2,6 +2,7 @@ import { Runtype } from './runtype';
 import { LiteralBase } from './types/literal';
 import { ConstraintCheck } from './types/constraint';
 import { Constructor } from './types/instanceof';
+import { Transformer } from './types/transform';
 
 export type Reflect =
   | ({ tag: 'unknown' } & Runtype)
@@ -31,6 +32,12 @@ export type Reflect =
       underlying: Reflect;
       constraint: ConstraintCheck<Runtype<never>>;
       args?: any;
+      name?: string;
+    } & Runtype)
+  | ({
+      tag: 'transform';
+      underlying: Reflect;
+      transformer: Transformer<Reflect, unknown>;
       name?: string;
     } & Runtype)
   | ({ tag: 'instanceof'; ctor: Constructor<unknown> } & Runtype)

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -105,7 +105,7 @@ export interface Runtype<A = unknown> {
    * helpful in reflection or diagnostic use-cases.
    */
   withTransform<T extends unknown, R extends Runtype = this>(
-    transformer: Transformer<R, T>,
+    transformer: Transformer<this, T>,
     options?: { name?: string },
   ): Transform<R, T>;
 

--- a/src/show.spec.ts
+++ b/src/show.spec.ts
@@ -68,6 +68,8 @@ const cases: [Reflect, string][] = [
   [Function, 'function'],
   [Lazy(() => Boolean), 'boolean'],
   [Number.withConstraint(x => x > 3), 'number'],
+  [String.withTransform(parseInt), 'string'],
+  [Array(String.withTransform(parseInt)), 'string[]'],
   [Number.withBrand('someNumber'), 'number'],
   [Number.withBrand('someNumber').withConstraint(x => x > 3), 'number'],
 

--- a/src/show.ts
+++ b/src/show.ts
@@ -53,6 +53,8 @@ const show = (needsParens: boolean, circular: Set<Reflect>) => (refl: Reflect): 
         return parenthesize(`${refl.intersectees.map(show(true, circular)).join(' & ')}`);
       case 'constraint':
         return refl.name || show(needsParens, circular)(refl.underlying);
+      case 'transform':
+        return refl.name || show(needsParens, circular)(refl.underlying);
       case 'instanceof':
         const name = (refl.ctor as any).name;
         return `InstanceOf<${name}>`;

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -29,18 +29,20 @@ function InternalArr<E extends Runtype, RO extends boolean>(
           };
         }
 
+        const result: typeof xs = [];
+
         for (const x of xs) {
-          let validated = innerValidate(element, x, visited);
+          const validated = innerValidate(element, x, visited);
           if (!validated.success) {
             return {
               success: false,
               message: validated.message,
               key: validated.key ? `[${xs.indexOf(x)}].${validated.key}` : `[${xs.indexOf(x)}]`,
             };
-          }
+          } else result.push(validated.value);
         }
 
-        return { success: true, value: xs };
+        return { success: true, value: result };
       },
       { tag: 'array', isReadonly, element },
     ),

--- a/src/types/dictionary.ts
+++ b/src/types/dictionary.ts
@@ -42,6 +42,8 @@ export function Dictionary<V extends Runtype>(value: V, key = 'string'): any {
           return { success: false, message: 'Expected dictionary, but was array' };
       }
 
+      const result: typeof x = {};
+
       for (const k in x) {
         // Object keys are unknown strings
         if (key === 'number') {
@@ -52,17 +54,17 @@ export function Dictionary<V extends Runtype>(value: V, key = 'string'): any {
             };
         }
 
-        let validated = innerValidate(value, (x as any)[k], visited);
+        const validated = innerValidate(value, (x as any)[k], visited);
         if (!validated.success) {
           return {
             success: false,
             message: validated.message,
             key: validated.key ? `${k}.${validated.key}` : k,
           };
-        }
+        } else result[k] = validated.value;
       }
 
-      return { success: true, value: x };
+      return { success: true, value: result };
     },
     { tag: 'dictionary', key, value },
   );

--- a/src/types/intersect.ts
+++ b/src/types/intersect.ts
@@ -219,13 +219,14 @@ export function Intersect<
 export function Intersect(...intersectees: Runtype[]): any {
   return create(
     (value, visited) => {
+      const result: typeof value = {};
+
       for (const targetType of intersectees) {
-        let validated = innerValidate(targetType, value, visited);
-        if (!validated.success) {
-          return validated;
-        }
+        const validated = innerValidate(targetType, value, visited);
+        if (!validated.success) return validated;
+        else Object.assign(result, validated.value);
       }
-      return { success: true, value };
+      return { success: true, value: result };
     },
     { tag: 'intersect', intersectees },
   );

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -56,21 +56,23 @@ export function InternalRecord<
           return { success: false, message: `Expected ${show(a)}, but was ${x}` };
         }
 
+        const result: typeof x = {};
+
         for (const key in fields) {
           if (!isPartial || (hasKey(key, x) && x[key] !== undefined)) {
             const value = isPartial || hasKey(key, x) ? x[key] : undefined;
-            let validated = innerValidate(fields[key], value, visited);
+            const validated = innerValidate(fields[key], value, visited);
             if (!validated.success) {
               return {
                 success: false,
                 message: validated.message,
                 key: validated.key ? `${key}.${validated.key}` : key,
               };
-            }
+            } else result[key] = validated.value;
           }
         }
 
-        return { success: true, value: x };
+        return { success: true, value: result };
       },
       { tag: 'record', isPartial, isReadonly, fields },
     ),

--- a/src/types/transform.spec.ts
+++ b/src/types/transform.spec.ts
@@ -1,0 +1,139 @@
+import {
+  Transform,
+  Static,
+  String,
+  Intersect,
+  Number,
+  Record,
+  Tuple,
+  Union,
+  Array,
+  InstanceOf,
+  Dictionary,
+} from '..';
+
+const Value = Union(Number, String);
+type Value = Static<typeof Value>;
+const toString = (x: Value) => x.toString();
+
+describe('transform', () => {
+  it('should convert value', () => {
+    const TrimmedString = Transform(String, s => s.trim());
+    expect(TrimmedString.check(' spaces around ')).toBe('spaces around');
+  });
+  it('should chain', () => {
+    const AppendedString = String.withTransform(s => s.trim()).withTransform(s => s + ' removed');
+    expect(AppendedString.check(' spaces around ')).toBe('spaces around removed');
+  });
+  it('should convert type', () => {
+    const ParsedInt = Transform(String, s => {
+      const parsed = parseInt(s);
+      if (isNaN(parsed)) throw new Error('Parse failed');
+      else return parsed;
+    });
+    type ParsedInt = Static<typeof ParsedInt>;
+    // Note that above type is inferred as: `number`
+    expect(ParsedInt.check('42')).toBe(42);
+  });
+  it('should throw error', () => {
+    const ParsedInt = Transform(String, s => {
+      const parsed = parseInt(s);
+      if (isNaN(parsed)) throw new Error('Parse failed');
+      else return parsed;
+    });
+    expect(() => ParsedInt.check('crap')).toThrowError('Parse failed');
+  });
+  it('should work with Dictionary', () => {
+    const Dict = Dictionary(Value.withTransform(toString));
+    type Dict = Static<typeof Dict>;
+    // Note that above type is inferred as:
+    // {
+    //     [_: string]: string;
+    // }
+    const expected = { value: '42' };
+    expect(Dict.check({ value: 42 })).toEqual(expected);
+    expect(Dict.check(expected)).toEqual(expected);
+  });
+  it('should work with Record and Union', () => {
+    const Object = Record({
+      value: Value.withTransform(toString),
+    });
+    const Complex = Union(
+      Value.withTransform(x => ({ value: toString(x) })),
+      Object,
+    );
+    type Complex = Static<typeof Complex>;
+    // Note that above type is inferred as:
+    // {
+    //     value: string;
+    // } | {
+    //     value: string;
+    // }
+    const expected = { value: '42' };
+    expect(Complex.check(42)).toEqual(expected);
+    expect(Complex.check('42')).toEqual(expected);
+    expect(Complex.check({ value: 42 })).toEqual(expected);
+    expect(Complex.check(expected)).toEqual(expected);
+  });
+  it('should work with Record and Intersect', () => {
+    const Object = Intersect(
+      Record({ x: Value.withTransform(toString) }),
+      Record({ y: Value.withTransform(toString) }),
+    );
+    type Object = Static<typeof Object>;
+    // Note that above type is inferred as:
+    // {
+    //     x: string;
+    // } & {
+    //     y: string;
+    // }
+    const expected = { x: '42', y: '24' };
+    expect(Object.check({ x: 42, y: 24 })).toEqual(expected);
+    expect(Object.check({ x: '42', y: 24 })).toEqual(expected);
+    expect(Object.check({ x: 42, y: '24' })).toEqual(expected);
+    expect(Object.check(expected)).toEqual(expected);
+  });
+  it('should work with Array', () => {
+    const Values = Array(Value.withTransform(toString));
+    type Values = Static<typeof Values>;
+    // Note that above type is inferred as:
+    // string[]
+    const expected = ['42', '24'];
+    expect(Values.check([42, 24])).toEqual(expected);
+    expect(Values.check(['42', 24])).toEqual(expected);
+    expect(Values.check([42, '24'])).toEqual(expected);
+    expect(Values.check(expected)).toEqual(expected);
+  });
+  it('should work with Tuple', () => {
+    const Values = Tuple(Value.withTransform(toString), Value.withTransform(toString));
+    type Values = Static<typeof Values>;
+    // Note that above type is inferred as:
+    // [string, string]
+    const expected = ['42', '24'];
+    expect(Values.check([42, 24])).toEqual(expected);
+    expect(Values.check(['42', 24])).toEqual(expected);
+    expect(Values.check([42, '24'])).toEqual(expected);
+    expect(Values.check(expected)).toEqual(expected);
+  });
+  it('should work with Brand', () => {
+    const BrandedValue = Value.withTransform(toString).withBrand('BrandedValue');
+    type BrandedValue = Static<typeof BrandedValue>;
+    // Note that above type is inferred as:
+    // string & {
+    //     [RuntypeName]: "BrandedValue";
+    // }
+    const expected = '42';
+    expect(BrandedValue.check(42)).toEqual(expected);
+    expect(BrandedValue.check(expected)).toEqual(expected);
+  });
+  it('should work with InstanceOf', () => {
+    const TwoUInt8s = InstanceOf(Buffer)
+      .withTransform(buffer => [buffer.readUInt8(0), buffer.readUInt8(1)] as const)
+      .withTransform(n => [toString(n[0]), toString(n[1])] as const);
+    type TwoUInt8s = Static<typeof TwoUInt8s>;
+    // Note that above type is inferred as:
+    // readonly [string, string]
+    const expected = ['42', '24'];
+    expect(TwoUInt8s.check(Buffer.from([42, 24]))).toEqual(expected);
+  });
+});

--- a/src/types/transform.spec.ts
+++ b/src/types/transform.spec.ts
@@ -12,6 +12,16 @@ import {
   Dictionary,
 } from '..';
 
+const ParsedInt = Transform(
+  String,
+  s => {
+    const parsed = parseInt(s);
+    if (isNaN(parsed)) throw new Error('Parse failed');
+    else return parsed;
+  },
+  { name: 'ParsedInt' },
+);
+
 const Value = Union(Number, String);
 type Value = Static<typeof Value>;
 const toString = (x: Value) => x.toString();
@@ -26,22 +36,15 @@ describe('transform', () => {
     expect(AppendedString.check(' spaces around ')).toBe('spaces around removed');
   });
   it('should convert type', () => {
-    const ParsedInt = Transform(String, s => {
-      const parsed = parseInt(s);
-      if (isNaN(parsed)) throw new Error('Parse failed');
-      else return parsed;
-    });
     type ParsedInt = Static<typeof ParsedInt>;
     // Note that above type is inferred as: `number`
-    expect(ParsedInt.check('42')).toBe(42);
+    const expected: ParsedInt = 42;
+    expect(ParsedInt.check('42')).toBe(expected);
   });
   it('should throw error', () => {
-    const ParsedInt = Transform(String, s => {
-      const parsed = parseInt(s);
-      if (isNaN(parsed)) throw new Error('Parse failed');
-      else return parsed;
-    });
-    expect(() => ParsedInt.check('crap')).toThrowError('Parse failed');
+    expect(() => ParsedInt.check('crap')).toThrowError(
+      'Failed transform of ParsedInt: Error: Parse failed',
+    );
   });
   it('should work with Dictionary', () => {
     const Dict = Dictionary(Value.withTransform(toString));

--- a/src/types/transform.ts
+++ b/src/types/transform.ts
@@ -1,0 +1,38 @@
+import { Runtype, Static, create } from '../runtype';
+
+export type Transformer<A extends Runtype, B extends unknown> = (x: Static<A>) => B;
+
+export interface Transform<A extends Runtype, B extends unknown> extends Runtype<B> {
+  tag: 'transform';
+  underlying: A;
+  transformer: Transformer<A, B>;
+  name?: string;
+}
+
+export function Transform<A extends Runtype, B extends unknown>(
+  underlying: A,
+  transformer: Transformer<A, B>,
+  options?: { name?: string },
+): Transform<A, B> {
+  return create<Transform<A, B>>(
+    value => {
+      const name = options && options.name;
+      const validated = underlying.validate(value);
+
+      if (!validated.success) return validated;
+      try {
+        const value = transformer(validated.value);
+        return { success: true, value };
+      } catch (error) {
+        const message = `Failed transform${name ? ` of ${name}` : ''}: ${error.toString()}`;
+        return { success: false, message };
+      }
+    },
+    {
+      tag: 'transform',
+      underlying,
+      transformer,
+      name: options && options.name,
+    },
+  );
+}

--- a/src/types/tuple.ts
+++ b/src/types/tuple.ts
@@ -243,8 +243,10 @@ export function Tuple(...components: Runtype[]): any {
         };
       }
 
+      const result: typeof x = [];
+
       for (let i = 0; i < components.length; i++) {
-        let validatedComponent = innerValidate(components[i], validated.value[i], visited);
+        const validatedComponent = innerValidate(components[i], validated.value[i], visited);
 
         if (!validatedComponent.success) {
           return {
@@ -252,10 +254,10 @@ export function Tuple(...components: Runtype[]): any {
             message: validatedComponent.message,
             key: validatedComponent.key ? `[${i}].${validatedComponent.key}` : `[${i}]`,
           };
-        }
+        } else result.push(validatedComponent.value);
       }
 
-      return { success: true, value: x };
+      return { success: true, value: result };
     },
     { tag: 'tuple', components },
   );

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -991,9 +991,8 @@ export function Union(...alternatives: Rt[]): any {
       }
 
       for (const targetType of alternatives) {
-        if (innerValidate(targetType, value, visited).success) {
-          return { success: true, value };
-        }
+        const validated = innerValidate(targetType, value, visited);
+        if (validated.success) return validated;
       }
 
       const a = create<any>(value as never, { tag: 'union', alternatives });


### PR DESCRIPTION
BREAKING CHANGE: `check` method of compound runtypes such as `Record` and `Tuple` now returns a new object instead of original one

Resolves #56. It's inspired by https://github.com/pelotom/runtypes/issues/56#issuecomment-757425403. Detailed usage is in the [tests](https://github.com/pelotom/runtypes/pull/191/files#diff-b075331330986a228557d856a506184846e4f748b2b7a5fce7b313fc6d73df45). Above change is needed in order to make `Transform` work with those non-primitive runtypes. Now investigating possible side effects, bugs & design flaws...

Example usage:

```ts
const Input = Record({
  date: String.withTransform(s => {
    const date = new Date(s);
    if (isNaN(date.valueOf())) throw new Error(`Invalid date string "${s}"`);
    else return date;
  }),
});
type Input = Static<typeof Input>;
// { date: Date; }

Input.check({ date: 'crap' });
// ValidationError: Failed transform: Error: Invalid date string "crap" in date

const input: Input = Input.check({ date: '1990-01-01' });
console.log(input.date.toUTCString());
// Mon, 01 Jan 1990 00:00:00 GMT
```