### PR TITLE
Branded types now compatible with `declaration` option of TS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,5 +24,5 @@ export * from './types/function';
 export { InstanceOf } from './types/instanceof';
 export * from './types/lazy';
 export * from './types/constraint';
-export { Brand } from './types/brand';
+export * from './types/brand';
 export * from './decorator';

--- a/src/types/brand.ts
+++ b/src/types/brand.ts
@@ -1,12 +1,16 @@
 import { Runtype, Static, create } from '../runtype';
 
-declare const RuntypeName: unique symbol;
+export declare const RuntypeName: unique symbol;
+
+export interface RuntypeBrand<B extends string> {
+  [RuntypeName]: B;
+}
 
 export interface Brand<B extends string, A extends Runtype>
   extends Runtype<
     // TODO: replace it by nominal type when it has been released
     // https://github.com/microsoft/TypeScript/pull/33038
-    Static<A> & { [RuntypeName]: B }
+    Static<A> & RuntypeBrand<B>
   > {
   tag: 'brand';
   brand: B;


### PR DESCRIPTION
Resolves #195. With this fix, the resulting static type of `String.withBrand("BrandedString")` will look like `string & RuntypeBrand<"BrandedString">`. This also makes tooltips more readable, especially for complex types, for example:

```ts
export const ID = String.withBrand('ID');
export type ID = Static<typeof ID>;

export const ArrayNonEmpty = <T extends Runtype>(element: T) =>
  Array(element).withConstraint(a => 0 < a.length || 'array must not be empty');

export const IDRequiedAndOptional = Record({ required: ArrayNonEmpty(ID) })
  .And(Partial({ optional: ArrayNonEmpty(ID) }))
  .withBrand('IDRequiedAndOptional');
export type IDRequiedAndOptional = Static<typeof IDRequiedAndOptional>;
```

Without this fix, the static type of `IDRequiedAndOptional` was being shown as:

```ts
type IDRequiedAndOptional = {
    required: (string & {
        [RuntypeName]: "ID";
    })[];
} & {
    optional?: (string & {
        [RuntypeName]: "ID";
    })[] | undefined;
} & {
    [RuntypeName]: "IDRequiedAndOptional";
}
```

But now:

```ts
type IDRequiedAndOptional = {
    required: (string & RuntypeBrand<"ID">)[];
} & {
    optional?: (string & RuntypeBrand<"ID">)[] | undefined;
} & RuntypeBrand<"IDRequiedAndOptional">
```

This is not a breaking change, because it's just an interface like following:

```ts
export interface RuntypeBrand<B extends string> {
  [RuntypeName]: B;
}
```