### PR TITLE
Feature: symbol key validation

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -629,6 +629,17 @@ describe('reflection', () => {
       Sym('runtypes?'),
       'Expected symbol key to be "runtypes?", but was "runtypes!"',
     );
+    assertAccepts(Symbol(), Sym(undefined));
+    assertThrows(
+      Symbol.for('undefined'),
+      Sym(undefined),
+      'Expected symbol key to be undefined, but was "undefined"',
+    );
+    assertThrows(
+      Symbol(),
+      Sym('undefined'),
+      'Expected symbol key to be "undefined", but was undefined',
+    );
   });
 
   it('literal', () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -123,6 +123,7 @@ const runtypes = {
   String,
   'hello world': Literal('hello world'),
   Sym,
+  SymForRuntypes: Sym('runtypes'),
   symbolArray: Array(Sym),
   boolArray: Array(Boolean),
   boolTuple,
@@ -201,7 +202,7 @@ const testValues: { value: unknown; passes: RuntypeName[] }[] = [
   { value: global.BigInt(42), passes: ['bigint', '42n'] },
   { value: 'hello world', passes: ['String', 'hello world', 'union1'] },
   { value: [Symbol('0'), Symbol(42), Symbol()], passes: ['symbolArray'] },
-  { value: Symbol.for('runtypes'), passes: ['Sym'] },
+  { value: Symbol.for('runtypes'), passes: ['Sym', 'SymForRuntypes'] },
   { value: [true, false, true], passes: ['boolArray', 'boolTuple', 'union1'] },
   { value: { Boolean: true, Number: 3 }, passes: ['record1', 'union1', 'Partial'] },
   { value: { Boolean: true }, passes: ['Partial'] },
@@ -619,6 +620,14 @@ describe('reflection', () => {
 
   it('symbol', () => {
     expectLiteralField(Sym, 'tag', 'symbol');
+    const SymForRuntypes = Sym('runtypes');
+    expectLiteralField(SymForRuntypes, 'tag', 'symbol');
+    expectLiteralField(SymForRuntypes, 'key', 'runtypes');
+    assertThrows(
+      Symbol.for('runtypes!'),
+      Sym('runtypes?'),
+      'Expected symbol key to be "runtypes?", but was "runtypes!"',
+    );
   });
 
   it('literal', () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -202,6 +202,7 @@ const testValues: { value: unknown; passes: RuntypeName[] }[] = [
   { value: global.BigInt(42), passes: ['bigint', '42n'] },
   { value: 'hello world', passes: ['String', 'hello world', 'union1'] },
   { value: [Symbol('0'), Symbol(42), Symbol()], passes: ['symbolArray'] },
+  { value: Symbol(), passes: ['Sym'] },
   { value: Symbol.for('runtypes'), passes: ['Sym', 'SymForRuntypes'] },
   { value: [true, false, true], passes: ['boolArray', 'boolTuple', 'union1'] },
   { value: { Boolean: true, Number: 3 }, passes: ['record1', 'union1', 'Partial'] },

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -11,8 +11,8 @@ export type Reflect =
   | ({ tag: 'number' } & Runtype<number>)
   | ({ tag: 'bigint' } & Runtype<bigint>)
   | ({ tag: 'string' } & Runtype<string>)
-  | ({ tag: 'symbol'; key: string } & Runtype<symbol>)
-  | ({ tag: 'symbol'; (key: string): Runtype<symbol> } & Runtype<symbol>)
+  | ({ tag: 'symbol'; key: string | undefined } & Runtype<symbol>)
+  | ({ tag: 'symbol'; (key: string | undefined): Runtype<symbol> } & Runtype<symbol>)
   | ({ tag: 'literal'; value: LiteralBase } & Runtype<LiteralBase>)
   | ({ tag: 'array'; element: Reflect; isReadonly: boolean } & Runtype<ReadonlyArray<unknown>>)
   | ({

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -11,7 +11,8 @@ export type Reflect =
   | ({ tag: 'number' } & Runtype<number>)
   | ({ tag: 'bigint' } & Runtype<bigint>)
   | ({ tag: 'string' } & Runtype<string>)
-  | ({ tag: 'symbol' } & Runtype<symbol>)
+  | ({ tag: 'symbol'; key: string } & Runtype<symbol>)
+  | ({ tag: 'symbol'; (key: string): Runtype<symbol> } & Runtype<symbol>)
   | ({ tag: 'literal'; value: LiteralBase } & Runtype<LiteralBase>)
   | ({ tag: 'array'; element: Reflect; isReadonly: boolean } & Runtype<ReadonlyArray<unknown>>)
   | ({

--- a/src/show.spec.ts
+++ b/src/show.spec.ts
@@ -37,6 +37,7 @@ const cases: [Reflect, string][] = [
   [BigInt, 'bigint'],
   [String, 'string'],
   [Symbol, 'symbol'],
+  [Symbol('runtypes'), 'symbol'],
   [Literal(true), 'true'],
   [Literal(3), '3'],
   [Literal('foo'), '"foo"'],

--- a/src/types/symbol.ts
+++ b/src/types/symbol.ts
@@ -1,21 +1,61 @@
 import { Runtype, create } from '../runtype';
 
-interface Sym extends Runtype<symbol> {
+export interface Symbol extends Runtype<symbol> {
   tag: 'symbol';
+  /**
+    Validates that a value is a symbol.
+    @param {string} key - Specify what key the symbol is for.
+   */
+  <K extends string>(key: K): SymbolFor<K>;
 }
+
+export interface SymbolFor<K extends string> extends Runtype<symbol> {
+  tag: 'symbol';
+  key: K;
+}
+
+const f = (key: string) =>
+  create<Symbol>(
+    value => {
+      if (typeof value !== 'symbol') {
+        return {
+          success: false,
+          message: `Expected symbol, but was ${
+            value === 'null' ? value : Array.isArray(value) ? 'array' : typeof value
+          }`,
+        };
+      } else {
+        const keyOfValue = global.Symbol.keyFor(value);
+        if (keyOfValue === undefined) {
+          return {
+            success: false,
+            message: `Expected symbol key to be "${key}", but was undefined`,
+          };
+        } else if (keyOfValue !== key) {
+          return {
+            success: false,
+            message: `Expected symbol key to be "${key}", but was "${keyOfValue}"`,
+          };
+        } else {
+          return { success: true, value };
+        }
+      }
+    },
+    { tag: 'symbol', key },
+  );
 
 /**
  * Validates that a value is a symbol.
  */
-const Sym = create<Sym>(
+export const Symbol = create<Symbol>(
   value =>
     typeof value === 'symbol'
       ? { success: true, value }
       : {
           success: false,
-          message: `Expected symbol, but was ${value === null ? value : typeof value}`,
+          message: `Expected symbol, but was ${
+            value === 'null' ? value : Array.isArray(value) ? 'array' : typeof value
+          }`,
         },
-  { tag: 'symbol' },
+  Object.assign(f, { tag: 'symbol' }),
 );
-
-export { Sym as Symbol };

--- a/src/types/symbol.ts
+++ b/src/types/symbol.ts
@@ -3,8 +3,8 @@ import { Runtype, create } from '../runtype';
 export interface Symbol extends Runtype<symbol> {
   tag: 'symbol';
   /**
-    Validates that a value is a symbol.
-    @param {string} key - Specify what key the symbol is for.
+    Validates that a value is a symbol with a specific key or without any key.
+    @param {string | undefined} key - Specify what key the symbol is for. If you want to ensure the validated symbol is *not* keyed, pass `undefined`.
    */
   <K extends string | undefined>(key: K): SymbolFor<K>;
 }
@@ -40,7 +40,7 @@ const f = (key: string | undefined) =>
   );
 
 /**
- * Validates that a value is a symbol.
+ * Validates that a value is a symbol, regardless of whether it is keyed or not.
  */
 export const Symbol = create<Symbol>(value => {
   if (typeof value !== 'symbol') {

--- a/src/types/symbol.ts
+++ b/src/types/symbol.ts
@@ -6,35 +6,30 @@ export interface Symbol extends Runtype<symbol> {
     Validates that a value is a symbol.
     @param {string} key - Specify what key the symbol is for.
    */
-  <K extends string>(key: K): SymbolFor<K>;
+  <K extends string | undefined>(key: K): SymbolFor<K>;
 }
 
-export interface SymbolFor<K extends string> extends Runtype<symbol> {
+export interface SymbolFor<K extends string | undefined> extends Runtype<symbol> {
   tag: 'symbol';
   key: K;
 }
 
-const f = (key: string) =>
+const f = (key: string | undefined) =>
   create<Symbol>(
     value => {
       if (typeof value !== 'symbol') {
         return {
           success: false,
-          message: `Expected symbol, but was ${
-            value === 'null' ? value : Array.isArray(value) ? 'array' : typeof value
-          }`,
+          message: `Expected symbol, but was ${typeStringOf(value)}`,
         };
       } else {
-        const keyOfValue = global.Symbol.keyFor(value);
-        if (keyOfValue === undefined) {
+        const keyForValue = global.Symbol.keyFor(value);
+        if (keyForValue !== key) {
           return {
             success: false,
-            message: `Expected symbol key to be "${key}", but was undefined`,
-          };
-        } else if (keyOfValue !== key) {
-          return {
-            success: false,
-            message: `Expected symbol key to be "${key}", but was "${keyOfValue}"`,
+            message: `Expected symbol key to be ${quoteIfPresent(key)}, but was ${quoteIfPresent(
+              keyForValue,
+            )}`,
           };
         } else {
           return { success: true, value };
@@ -47,15 +42,18 @@ const f = (key: string) =>
 /**
  * Validates that a value is a symbol.
  */
-export const Symbol = create<Symbol>(
-  value =>
-    typeof value === 'symbol'
-      ? { success: true, value }
-      : {
-          success: false,
-          message: `Expected symbol, but was ${
-            value === 'null' ? value : Array.isArray(value) ? 'array' : typeof value
-          }`,
-        },
-  Object.assign(f, { tag: 'symbol' }),
-);
+export const Symbol = create<Symbol>(value => {
+  if (typeof value !== 'symbol') {
+    return {
+      success: false,
+      message: `Expected symbol, but was ${typeStringOf(value)}`,
+    };
+  } else {
+    return { success: true, value };
+  }
+}, Object.assign(f, { tag: 'symbol' }));
+
+const quoteIfPresent = (key: string | undefined) => (key === undefined ? 'undefined' : `"${key}"`);
+
+const typeStringOf = (value: unknown) =>
+  value === null ? 'null' : Array.isArray(value) ? 'array' : typeof value;


### PR DESCRIPTION
`Symbol` runtype now has a call signature `<K extends string | undefined>(key: K): SymbolFor<K>;`. You can use just `const S = Symbol` for any symbols, `const T = Symbol("T")` for keyed symbols, and `const U = Symbol(undefined)` for non-keyed symbols.