### PR TITLE
Refactor: unuse `Exclude` internally in static type of `Record`

### DIFF
--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -3,18 +3,12 @@ import { enumerableKeysOf, FAILURE, hasKey, SUCCESS } from '../util';
 import { Optional } from './optional';
 import { Details, Result } from '../result';
 
-type FilterOptionalKeys<T> = Exclude<
-  {
-    [K in keyof T]: T[K] extends Optional<any> ? K : never;
-  }[keyof T],
-  undefined
->;
-type FilterRequiredKeys<T> = Exclude<
-  {
-    [K in keyof T]: T[K] extends Optional<any> ? never : K;
-  }[keyof T],
-  undefined
->;
+type FilterOptionalKeys<T> = {
+  [K in keyof T]: T[K] extends Optional<any> ? K : never;
+}[keyof T];
+type FilterRequiredKeys<T> = {
+  [K in keyof T]: T[K] extends Optional<any> ? never : K;
+}[keyof T];
 
 type MergedRecord<O extends { [_: string]: Runtype }> = {
   [K in FilterRequiredKeys<O>]: Static<O[K]>;


### PR DESCRIPTION
This change https://github.com/pelotom/runtypes/issues/212#issuecomment-816855930 does not solve the issue #212, but at least it would reduce complexity.