### PR TITLE
Refactor: widen type parameter boundary to `RuntypeBase`

### DIFF
--- a/src/asynccontract.ts
+++ b/src/asynccontract.ts
@@ -1,18 +1,17 @@
-import { Runtype } from './index';
 import { ValidationError } from './errors';
-import { Static } from './runtype';
+import { RuntypeBase, Static } from './runtype';
 import { FAILURE } from './util';
 
-export interface AsyncContract<A extends readonly Runtype[], R extends Runtype> {
+export interface AsyncContract<A extends readonly RuntypeBase[], R extends RuntypeBase> {
   enforce(
     f: (
       ...args: {
-        [key in keyof A]: A[key] extends Runtype ? Static<A[key]> : unknown;
+        [K in keyof A]: A[K] extends RuntypeBase ? Static<A[K]> : unknown;
       }
     ) => Promise<Static<R>>,
   ): (
     ...args: {
-      [key in keyof A]: A[key] extends Runtype ? Static<A[key]> : unknown;
+      [K in keyof A]: A[K] extends RuntypeBase ? Static<A[K]> : unknown;
     }
   ) => Promise<Static<R>>;
 }
@@ -20,11 +19,11 @@ export interface AsyncContract<A extends readonly Runtype[], R extends Runtype> 
 /**
  * Create a function contract.
  */
-export function AsyncContract<A extends readonly Runtype[], R extends Runtype>(
+export function AsyncContract<A extends readonly RuntypeBase[], R extends RuntypeBase>(
   ...runtypes: [...A, R]
 ): AsyncContract<A, R>;
 
-export function AsyncContract<A extends readonly Runtype[], R extends Runtype>(
+export function AsyncContract<A extends readonly RuntypeBase[], R extends RuntypeBase>(
   ...runtypes: [...A, R]
 ): AsyncContract<A, R> {
   const lastIndex = runtypes.length - 1;
@@ -34,12 +33,12 @@ export function AsyncContract<A extends readonly Runtype[], R extends Runtype>(
     enforce: (
       f: (
         ...args: {
-          [key in keyof A]: A[key] extends Runtype ? Static<A[key]> : unknown;
+          [K in keyof A]: A[K] extends RuntypeBase ? Static<A[K]> : unknown;
         }
       ) => Promise<Static<R>>,
     ) => (
       ...args: {
-        [key in keyof A]: A[key] extends Runtype ? Static<A[key]> : unknown;
+        [K in keyof A]: A[K] extends RuntypeBase ? Static<A[K]> : unknown;
       }
     ): Promise<Static<R>> => {
       if (args.length < argRuntypes.length) {

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,18 +1,17 @@
-import { Runtype } from './index';
 import { ValidationError } from './errors';
-import { Static } from './runtype';
+import { RuntypeBase, Static } from './runtype';
 import { FAILURE } from './util';
 
-export interface Contract<A extends readonly Runtype[], R extends Runtype> {
+export interface Contract<A extends readonly RuntypeBase[], R extends RuntypeBase> {
   enforce(
     f: (
       ...args: {
-        [key in keyof A]: A[key] extends Runtype ? Static<A[key]> : unknown;
+        [K in keyof A]: A[K] extends RuntypeBase ? Static<A[K]> : unknown;
       }
     ) => Static<R>,
   ): (
     ...args: {
-      [key in keyof A]: A[key] extends Runtype ? Static<A[key]> : unknown;
+      [K in keyof A]: A[K] extends RuntypeBase ? Static<A[K]> : unknown;
     }
   ) => Static<R>;
 }
@@ -20,11 +19,11 @@ export interface Contract<A extends readonly Runtype[], R extends Runtype> {
 /**
  * Create a function contract.
  */
-export function Contract<A extends readonly Runtype[], R extends Runtype>(
+export function Contract<A extends readonly RuntypeBase[], R extends RuntypeBase>(
   ...runtypes: [...A, R]
 ): Contract<A, R>;
 
-export function Contract<A extends readonly Runtype[], R extends Runtype>(
+export function Contract<A extends readonly RuntypeBase[], R extends RuntypeBase>(
   ...runtypes: [...A, R]
 ): Contract<A, R> {
   const lastIndex = runtypes.length - 1;
@@ -34,12 +33,12 @@ export function Contract<A extends readonly Runtype[], R extends Runtype>(
     enforce: (
       f: (
         ...args: {
-          [key in keyof A]: A[key] extends Runtype ? Static<A[key]> : unknown;
+          [K in keyof A]: A[K] extends RuntypeBase ? Static<A[K]> : unknown;
         }
       ) => Static<R>,
     ) => (
       ...args: {
-        [key in keyof A]: A[key] extends Runtype ? Static<A[key]> : unknown;
+        [K in keyof A]: A[K] extends RuntypeBase ? Static<A[K]> : unknown;
       }
     ): Static<R> => {
       if (args.length < argRuntypes.length) {

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -1,4 +1,4 @@
-import { Runtype } from './runtype';
+import { RuntypeBase } from './runtype';
 import { ValidationError } from './errors';
 import { FAILURE } from './util';
 
@@ -58,7 +58,7 @@ function getValidParameterIndices(target: any, propertyKey: PropKey, runtypeCoun
  * }
  * ```
  */
-export function checked(...runtypes: Runtype[]) {
+export function checked(...runtypes: RuntypeBase[]) {
   if (runtypes.length === 0) {
     throw new Error('No runtype provided to `@checked`. Please remove the decorator.');
   }

--- a/src/match.ts
+++ b/src/match.ts
@@ -1,4 +1,5 @@
-import { Runtype as Rt, Case, Matcher } from '.';
+import { RuntypeBase } from './runtype';
+import { Case, Matcher } from './types/union';
 
 export function match<A extends [PairCase<any, any>, ...PairCase<any, any>[]]>(
   ...cases: A
@@ -16,4 +17,4 @@ export function match<A extends [PairCase<any, any>, ...PairCase<any, any>[]]>(
   };
 }
 
-export type PairCase<A extends Rt, Z> = [A, Case<A, Z>];
+export type PairCase<A extends RuntypeBase, Z> = [A, Case<A, Z>];

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -1,4 +1,13 @@
-import { Result, Union, Intersect, Optional, Constraint, ConstraintCheck, Brand } from './index';
+import {
+  Result,
+  Union,
+  Intersect,
+  Optional,
+  Constraint,
+  ConstraintCheck,
+  Brand,
+  Null,
+} from './index';
 import { Reflect } from './reflect';
 import show from './show';
 import { ValidationError } from './errors';
@@ -57,6 +66,11 @@ export interface Runtype<A = unknown> extends RuntypeBase<A> {
    * Optionalize this Runtype.
    */
   optional(): Optional<this>;
+
+  /**
+   * Union this Runtype with `Null`.
+   */
+  nullable(): Union<[this, typeof Null]>;
 
   /**
    * Use an arbitrary constraint function to validate a runtype, and optionally

--- a/src/types/array.ts
+++ b/src/types/array.ts
@@ -1,13 +1,13 @@
 import { Reflect } from '../reflect';
 import { Details, Result } from '../result';
-import { Runtype, Static, create, innerValidate } from '../runtype';
+import { Runtype, RuntypeBase, Static, create, innerValidate } from '../runtype';
 import { enumerableKeysOf, FAILURE, SUCCESS } from '../util';
 
-type ArrayStaticType<E extends Runtype, RO extends boolean> = RO extends true
+type ArrayStaticType<E extends RuntypeBase, RO extends boolean> = RO extends true
   ? ReadonlyArray<Static<E>>
   : Static<E>[];
 
-interface Arr<E extends Runtype, RO extends boolean> extends Runtype<ArrayStaticType<E, RO>> {
+interface Arr<E extends RuntypeBase, RO extends boolean> extends Runtype<ArrayStaticType<E, RO>> {
   tag: 'array';
   element: E;
   isReadonly: RO;
@@ -18,7 +18,7 @@ interface Arr<E extends Runtype, RO extends boolean> extends Runtype<ArrayStatic
 /**
  * Construct an array runtype from a runtype for its elements.
  */
-function InternalArr<E extends Runtype, RO extends boolean>(
+function InternalArr<E extends RuntypeBase, RO extends boolean>(
   element: E,
   isReadonly: RO,
 ): Arr<E, RO> {
@@ -46,11 +46,11 @@ function InternalArr<E extends Runtype, RO extends boolean>(
   );
 }
 
-function Arr<E extends Runtype, RO extends boolean>(element: E): Arr<E, false> {
+function Arr<E extends RuntypeBase, RO extends boolean>(element: E): Arr<E, false> {
   return InternalArr(element, false);
 }
 
-function withExtraModifierFuncs<E extends Runtype, RO extends boolean>(A: any): Arr<E, RO> {
+function withExtraModifierFuncs<E extends RuntypeBase, RO extends boolean>(A: any): Arr<E, RO> {
   A.asReadonly = asReadonly;
 
   return A;

--- a/src/types/brand.ts
+++ b/src/types/brand.ts
@@ -1,5 +1,5 @@
 import { Reflect } from '../reflect';
-import { Runtype, Static, create } from '../runtype';
+import { Runtype, RuntypeBase, Static, create } from '../runtype';
 
 export declare const RuntypeName: unique symbol;
 
@@ -7,7 +7,7 @@ export interface RuntypeBrand<B extends string> {
   [RuntypeName]: B;
 }
 
-export interface Brand<B extends string, A extends Runtype>
+export interface Brand<B extends string, A extends RuntypeBase>
   extends Runtype<
     // TODO: replace it by nominal type when it has been released
     // https://github.com/microsoft/TypeScript/pull/33038
@@ -18,7 +18,7 @@ export interface Brand<B extends string, A extends Runtype>
   entity: A;
 }
 
-export function Brand<B extends string, A extends Runtype>(brand: B, entity: A) {
+export function Brand<B extends string, A extends RuntypeBase>(brand: B, entity: A) {
   const self = ({ tag: 'brand', brand, entity } as unknown) as Reflect;
   return create<any>(value => entity.validate(value), self);
 }

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -1,11 +1,11 @@
 import { Reflect } from '../reflect';
-import { Runtype, Static, create } from '../runtype';
+import { Runtype, RuntypeBase, Static, create } from '../runtype';
 import { FAILURE, SUCCESS } from '../util';
 import { Unknown } from './unknown';
 
-export type ConstraintCheck<A extends Runtype> = (x: Static<A>) => boolean | string;
+export type ConstraintCheck<A extends RuntypeBase> = (x: Static<A>) => boolean | string;
 
-export interface Constraint<A extends Runtype, T extends Static<A> = Static<A>, K = unknown>
+export interface Constraint<A extends RuntypeBase, T extends Static<A> = Static<A>, K = unknown>
   extends Runtype<T> {
   tag: 'constraint';
   underlying: A;
@@ -16,7 +16,7 @@ export interface Constraint<A extends Runtype, T extends Static<A> = Static<A>, 
   args?: K;
 }
 
-export function Constraint<A extends Runtype, T extends Static<A> = Static<A>, K = unknown>(
+export function Constraint<A extends RuntypeBase, T extends Static<A> = Static<A>, K = unknown>(
   underlying: A,
   constraint: ConstraintCheck<A>,
   options?: { name?: string; args?: K },

--- a/src/types/dictionary.ts
+++ b/src/types/dictionary.ts
@@ -1,4 +1,4 @@
-import { Runtype, create, Static, innerValidate } from '../runtype';
+import { Runtype, RuntypeBase, create, Static, innerValidate } from '../runtype';
 import { String } from './string';
 import { Constraint } from './constraint';
 import show from '../show';
@@ -17,20 +17,22 @@ type DictionaryKeyRuntype = Runtype<string | number | symbol>;
 
 const NumberKey = Constraint(String, s => !isNaN(+s), { name: 'number' });
 
-export interface Dictionary<V extends Runtype, K extends DictionaryKeyType>
+export interface Dictionary<V extends RuntypeBase, K extends DictionaryKeyType>
   extends Runtype<{ [_ in K]: Static<V> }> {
   tag: 'dictionary';
   key: StringLiteralFor<K>;
   value: V;
 }
 
-export interface StringDictionary<V extends Runtype> extends Runtype<{ [_: string]: Static<V> }> {
+export interface StringDictionary<V extends RuntypeBase>
+  extends Runtype<{ [_: string]: Static<V> }> {
   tag: 'dictionary';
   key: 'string';
   value: V;
 }
 
-export interface NumberDictionary<V extends Runtype> extends Runtype<{ [_: number]: Static<V> }> {
+export interface NumberDictionary<V extends RuntypeBase>
+  extends Runtype<{ [_: number]: Static<V> }> {
   tag: 'dictionary';
   key: 'number';
   value: V;
@@ -41,7 +43,7 @@ export interface NumberDictionary<V extends Runtype> extends Runtype<{ [_: numbe
  * @param value - A `Runtype` for value.
  * @param [key] - A `Runtype` for key.
  */
-export function Dictionary<V extends Runtype, K extends DictionaryKeyRuntype>(
+export function Dictionary<V extends RuntypeBase, K extends DictionaryKeyRuntype>(
   value: V,
   key?: K,
 ): Dictionary<V, Static<K>>;
@@ -52,7 +54,7 @@ export function Dictionary<V extends Runtype, K extends DictionaryKeyRuntype>(
  * @param value - A `Runtype` for value.
  * @param [key] - A string representing a type for key.
  */
-export function Dictionary<V extends Runtype>(value: V, key: 'string'): StringDictionary<V>;
+export function Dictionary<V extends RuntypeBase>(value: V, key: 'string'): StringDictionary<V>;
 
 /**
  * Construct a runtype for arbitrary dictionaries.
@@ -60,9 +62,12 @@ export function Dictionary<V extends Runtype>(value: V, key: 'string'): StringDi
  * @param value - A `Runtype` for value.
  * @param [key] - A string representing a type for key.
  */
-export function Dictionary<V extends Runtype>(value: V, key: 'number'): NumberDictionary<V>;
+export function Dictionary<V extends RuntypeBase>(value: V, key: 'number'): NumberDictionary<V>;
 
-export function Dictionary<V extends Runtype, K extends DictionaryKeyRuntype | 'string' | 'number'>(
+export function Dictionary<
+  V extends RuntypeBase,
+  K extends DictionaryKeyRuntype | 'string' | 'number'
+>(
   value: V,
   key?: K,
 ): K extends DictionaryKeyRuntype

--- a/src/types/intersect.ts
+++ b/src/types/intersect.ts
@@ -1,13 +1,13 @@
 import { Reflect } from '../reflect';
-import { Runtype, Static, create, innerValidate } from '../runtype';
+import { Runtype, RuntypeBase, Static, create, innerValidate } from '../runtype';
 import { SUCCESS } from '../util';
 
-export interface Intersect<A extends readonly [Runtype, ...Runtype[]]>
+export interface Intersect<A extends readonly [RuntypeBase, ...RuntypeBase[]]>
   extends Runtype<
     // We use the fact that a union of functions is effectively an intersection of parameters
     // e.g. to safely call (({x: 1}) => void | ({y: 2}) => void) you must pass {x: 1, y: 2}
     {
-      [key in keyof A]: A[key] extends Runtype ? (parameter: Static<A[key]>) => any : unknown;
+      [K in keyof A]: A[K] extends RuntypeBase ? (parameter: Static<A[K]>) => any : unknown;
     }[number] extends (k: infer I) => void
       ? I
       : never
@@ -19,7 +19,7 @@ export interface Intersect<A extends readonly [Runtype, ...Runtype[]]>
 /**
  * Construct an intersection runtype from runtypes for its alternatives.
  */
-export function Intersect<A extends readonly [Runtype, ...Runtype[]]>(
+export function Intersect<A extends readonly [RuntypeBase, ...RuntypeBase[]]>(
   ...intersectees: A
 ): Intersect<A> {
   const self = ({ tag: 'intersect', intersectees } as unknown) as Reflect;

--- a/src/types/optional.ts
+++ b/src/types/optional.ts
@@ -1,8 +1,8 @@
 import { Reflect } from '../reflect';
-import { Runtype, create, Static } from '../runtype';
+import { Runtype, RuntypeBase, create, Static } from '../runtype';
 import { SUCCESS } from '../util';
 
-export interface Optional<R extends Runtype> extends Runtype<Static<R> | undefined> {
+export interface Optional<R extends RuntypeBase> extends Runtype<Static<R> | undefined> {
   tag: 'optional';
   underlying: R;
 }
@@ -10,7 +10,7 @@ export interface Optional<R extends Runtype> extends Runtype<Static<R> | undefin
 /**
  * Validates optional value.
  */
-export function Optional<R extends Runtype>(runtype: R) {
+export function Optional<R extends RuntypeBase>(runtype: R) {
   const self = ({ tag: 'optional', underlying: runtype } as unknown) as Reflect;
   return create<Optional<R>>(
     value => (value === undefined ? SUCCESS(value) : runtype.validate(value)),

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -1,4 +1,4 @@
-import { Runtype, Static, create, innerValidate } from '../runtype';
+import { Runtype, RuntypeBase, Static, create, innerValidate } from '../runtype';
 import { enumerableKeysOf, FAILURE, hasKey, SUCCESS } from '../util';
 import { Optional } from './optional';
 import { Details, Result } from '../result';
@@ -10,7 +10,7 @@ type FilterRequiredKeys<T> = {
   [K in keyof T]: T[K] extends Optional<any> ? never : K;
 }[keyof T];
 
-type MergedRecord<O extends { [_: string]: Runtype }> = {
+type MergedRecord<O extends { [_: string]: RuntypeBase }> = {
   [K in FilterRequiredKeys<O>]: Static<O[K]>;
 } &
   {
@@ -19,7 +19,7 @@ type MergedRecord<O extends { [_: string]: Runtype }> = {
   ? { [K in keyof P]: P[K] }
   : never;
 
-type MergedRecordReadonly<O extends { [_: string]: Runtype }> = {
+type MergedRecordReadonly<O extends { [_: string]: RuntypeBase }> = {
   [K in FilterRequiredKeys<O>]: Static<O[K]>;
 } &
   {
@@ -29,7 +29,7 @@ type MergedRecordReadonly<O extends { [_: string]: Runtype }> = {
   : never;
 
 type RecordStaticType<
-  O extends { [_: string]: Runtype },
+  O extends { [_: string]: RuntypeBase },
   Part extends boolean,
   RO extends boolean
 > = Part extends true
@@ -41,7 +41,7 @@ type RecordStaticType<
   : MergedRecord<O>;
 
 export interface InternalRecord<
-  O extends { [_: string]: Runtype },
+  O extends { [_: string]: RuntypeBase },
   Part extends boolean,
   RO extends boolean
 > extends Runtype<RecordStaticType<O, Part, RO>> {
@@ -54,13 +54,13 @@ export interface InternalRecord<
   asReadonly(): InternalRecord<O, Part, true>;
 }
 
-export type Record<O extends { [_: string]: Runtype }, RO extends boolean> = InternalRecord<
+export type Record<O extends { [_: string]: RuntypeBase }, RO extends boolean> = InternalRecord<
   O,
   false,
   RO
 >;
 
-export type Partial<O extends { [_: string]: Runtype }, RO extends boolean> = InternalRecord<
+export type Partial<O extends { [_: string]: RuntypeBase }, RO extends boolean> = InternalRecord<
   O,
   true,
   RO
@@ -70,7 +70,7 @@ export type Partial<O extends { [_: string]: Runtype }, RO extends boolean> = In
  * Construct a record runtype from runtypes for its values.
  */
 export function InternalRecord<
-  O extends { [_: string]: Runtype },
+  O extends { [_: string]: RuntypeBase },
   Part extends boolean,
   RO extends boolean
 >(fields: O, isPartial: Part, isReadonly: RO): InternalRecord<O, Part, RO> {
@@ -129,16 +129,16 @@ export function InternalRecord<
   );
 }
 
-export function Record<O extends { [_: string]: Runtype }>(fields: O): Record<O, false> {
+export function Record<O extends { [_: string]: RuntypeBase }>(fields: O): Record<O, false> {
   return InternalRecord(fields, false, false);
 }
 
-export function Partial<O extends { [_: string]: Runtype }>(fields: O): Partial<O, false> {
+export function Partial<O extends { [_: string]: RuntypeBase }>(fields: O): Partial<O, false> {
   return InternalRecord(fields, true, false);
 }
 
 function withExtraModifierFuncs<
-  O extends { [_: string]: Runtype },
+  O extends { [_: string]: RuntypeBase },
   Part extends boolean,
   RO extends boolean
 >(A: any): InternalRecord<O, Part, RO> {

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -3,18 +3,12 @@ import { enumerableKeysOf, FAILURE, hasKey, SUCCESS } from '../util';
 import { Optional } from './optional';
 import { Details, Result } from '../result';
 
-type FilterOptionalKeys<T> = Exclude<
-  {
-    [K in keyof T]: T[K] extends Optional<any> ? K : never;
-  }[keyof T],
-  undefined
->;
-type FilterRequiredKeys<T> = Exclude<
-  {
-    [K in keyof T]: T[K] extends Optional<any> ? never : K;
-  }[keyof T],
-  undefined
->;
+type FilterOptionalKeys<T> = {
+  [K in keyof T]: T[K] extends Optional<any> ? K : never;
+}[keyof T];
+type FilterRequiredKeys<T> = {
+  [K in keyof T]: T[K] extends Optional<any> ? never : K;
+}[keyof T];
 
 type MergedRecord<O extends { [_: string]: Runtype }> = {
   [K in FilterRequiredKeys<O>]: Static<O[K]>;

--- a/src/types/tuple.ts
+++ b/src/types/tuple.ts
@@ -1,12 +1,12 @@
 import { Reflect } from '../reflect';
 import { Details, Result } from '../result';
-import { Runtype, Static, create, innerValidate } from '../runtype';
+import { Runtype, RuntypeBase, Static, create, innerValidate } from '../runtype';
 import { enumerableKeysOf, FAILURE, SUCCESS } from '../util';
 
-export interface Tuple<A extends readonly Runtype[]>
+export interface Tuple<A extends readonly RuntypeBase[]>
   extends Runtype<
     {
-      [key in keyof A]: A[key] extends Runtype ? Static<A[key]> : unknown;
+      [key in keyof A]: A[key] extends RuntypeBase ? Static<A[key]> : unknown;
     }
   > {
   tag: 'tuple';
@@ -16,7 +16,7 @@ export interface Tuple<A extends readonly Runtype[]>
 /**
  * Construct a tuple runtype from runtypes for each of its elements.
  */
-export function Tuple<T extends readonly Runtype[]>(...components: T): Tuple<T> {
+export function Tuple<T extends readonly RuntypeBase[]>(...components: T): Tuple<T> {
   const self = ({ tag: 'tuple', components } as unknown) as Reflect;
   return create<any>((xs, visited) => {
     if (!Array.isArray(xs)) return FAILURE.TYPE_INCORRECT(self, xs);

--- a/src/types/union.ts
+++ b/src/types/union.ts
@@ -1,12 +1,12 @@
-import { Runtype, RuntypeBase as Rt, Static, create, innerValidate } from '../runtype';
+import { Runtype, RuntypeBase, Static, create, innerValidate } from '../runtype';
 import { LiteralBase } from './literal';
 import { FAILURE, hasKey, SUCCESS } from '../util';
 import { Reflect } from '../reflect';
 
-export interface Union<A extends readonly [Rt, ...Rt[]]>
+export interface Union<A extends readonly [RuntypeBase, ...RuntypeBase[]]>
   extends Runtype<
     {
-      [key in keyof A]: A[key] extends Rt ? Static<A[key]> : unknown;
+      [K in keyof A]: A[K] extends RuntypeBase ? Static<A[K]> : unknown;
     }[number]
   > {
   tag: 'union';
@@ -17,7 +17,9 @@ export interface Union<A extends readonly [Rt, ...Rt[]]>
 /**
  * Construct a union runtype from runtypes for its alternatives.
  */
-export function Union<T extends readonly [Rt, ...Rt[]]>(...alternatives: T): Union<T> {
+export function Union<T extends readonly [RuntypeBase, ...RuntypeBase[]]>(
+  ...alternatives: T
+): Union<T> {
   const match = (...cases: any[]) => (x: any) => {
     for (let i = 0; i < alternatives.length; i++) {
       if (alternatives[i].guard(x)) {
@@ -33,7 +35,7 @@ export function Union<T extends readonly [Rt, ...Rt[]]>(...alternatives: T): Uni
       return FAILURE.TYPE_INCORRECT(self, value);
     }
 
-    const commonLiteralFields: { [key: string]: LiteralBase[] } = {};
+    const commonLiteralFields: { [K: string]: LiteralBase[] } = {};
     for (const alternative of alternatives) {
       if (alternative.reflect.tag === 'record') {
         for (const fieldName in alternative.reflect.fields) {
@@ -75,14 +77,14 @@ export function Union<T extends readonly [Rt, ...Rt[]]>(...alternatives: T): Uni
   }, self);
 }
 
-export interface Match<A extends readonly [Rt, ...Rt[]]> {
-  <Z>(...a: { [key in keyof A]: A[key] extends Rt ? Case<A[key], Z> : never }): Matcher<A, Z>;
+export interface Match<A extends readonly [RuntypeBase, ...RuntypeBase[]]> {
+  <Z>(...a: { [K in keyof A]: A[K] extends RuntypeBase ? Case<A[K], Z> : never }): Matcher<A, Z>;
 }
 
-export type Case<T extends Rt, Result> = (v: Static<T>) => Result;
+export type Case<T extends RuntypeBase, Result> = (v: Static<T>) => Result;
 
-export type Matcher<A extends readonly [Rt, ...Rt[]], Z> = (
+export type Matcher<A extends readonly [RuntypeBase, ...RuntypeBase[]], Z> = (
   x: {
-    [key in keyof A]: A[key] extends Rt<infer Type> ? Type : unknown;
+    [K in keyof A]: A[K] extends RuntypeBase<infer Type> ? Type : unknown;
   }[number],
 ) => Z;


### PR DESCRIPTION
Related to #212. This will simplify type instanciation substantially.