### PR TITLE
Handle objects with null prototypes

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -514,6 +514,18 @@ describe('check errors', () => {
     );
   });
 
+  it('record for null prototype', () =>
+    assertAccepts(
+      Object.assign(Object.create(null), {
+        name: 'Jack',
+        age: 10,
+      }),
+      Record({
+        name: String,
+        age: Number,
+      }),
+    ));
+
   it('record missing keys', () => {
     assertThrows(
       { name: 'Jack' },

--- a/src/util.ts
+++ b/src/util.ts
@@ -25,7 +25,8 @@ export const typeOf = (value: unknown) =>
 
 export const enumerableKeysOf = (object: unknown) =>
   typeof object === 'object' && object !== null
-    ? Reflect.ownKeys(object).filter(key => object.propertyIsEnumerable(key))
+    ? // Objects with a null prototype may not have `propertyIsEnumerable`
+      Reflect.ownKeys(object).filter(key => object.propertyIsEnumerable?.(key) ?? true)
     : [];
 
 export function SUCCESS<T extends unknown>(value: T): Success<T> {


### PR DESCRIPTION
It's currently possible to crash e.g. `Runtype.validate` by passing in an object with a null prototype. This may seem like an odd thing to do, but it's employed by some popular packages like Apollo Server and Koa, and can be observed by trying to validate some Koa query params.

```
TypeError: object?.propertyIsEnumerable is not a function
    at ./node_modules/runtypes/lib/util.js:37:126
    at Array.filter (<anonymous>)
    at Object.enumerableKeysOf (./node_modules/runtypes/lib/util.js:37:35)
    at ./node_modules/runtypes/lib/types/record.js:39:122
    at Object.A._innerValidate (./node_modules/runtypes/lib/runtype.js:14:16)
    at Object.A.validate (./node_modules/runtypes/lib/runtype.js:16:46)
```