### PR TITLE
Refactor: use `any` for internal type assertion

### DIFF
--- a/src/show.ts
+++ b/src/show.ts
@@ -1,5 +1,4 @@
 import { Reflect } from './index';
-import { Optional } from './types/optional';
 
 const show = (needsParens: boolean, circular: Set<Reflect>) => (refl: Reflect): string => {
   const parenthesize = (s: string) => (needsParens ? `(${s})` : s);
@@ -41,7 +40,7 @@ const show = (needsParens: boolean, circular: Set<Reflect>) => (refl: Reflect): 
                 k =>
                   `${readonlyTag(refl)}${k}${partialTag(refl, k)}: ${
                     refl.fields[k].tag === 'optional'
-                      ? show(false, circular)((refl.fields[k] as Optional<any>).underlying)
+                      ? show(false, circular)((refl.fields[k] as any).underlying)
                       : show(false, circular)(refl.fields[k])
                   };`,
               )


### PR DESCRIPTION
I don't know why but #230 led TS to emit compile-time error in show.ts, only when `yarn build`, not `yarn test`. It's actually not necessarily required to assert the reflect object as `Optional<...>`  at the relevant position, so we can use `any` safely here.