### PR TITLE
Revert "Remove workaround for resolved TypeScript issue (#230)"

### DIFF
--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -9,7 +9,9 @@ export interface Constraint<A extends RuntypeBase, T extends Static<A> = Static<
   extends Runtype<T> {
   tag: 'constraint';
   underlying: A;
-  constraint: ConstraintCheck<A>;
+  // See: https://github.com/Microsoft/TypeScript/issues/19746 for why this isn't just
+  // `constraint: ConstraintCheck<A>`
+  constraint(x: Static<A>): boolean | string;
   name?: string;
   args?: K;
 }


### PR DESCRIPTION
This reverts commit cb8809d3bb5c590ab76cee983ecf7eb66ce36087.

See #232. Apparently #230 broke `Lazy` runtype, so we should revert it until we have a solution for this.