### PR TITLE
Feature: add `extend` helper function to `Record`

### DIFF
--- a/src/types/record.spec.ts
+++ b/src/types/record.spec.ts
@@ -71,8 +71,9 @@ describe('record', () => {
       const PetMember = CrewMember.extend({ name: Literal('pet') });
       type PetMember = Static<typeof PetMember>;
       const petMember: PetMember = { name: 'pet', home: '', rank: '' };
-      expect(Object.keys(PetMember.fields)).toEqual(['name', 'rank', 'home']);
+      const anotherMember = { name: 'another', home: '', rank: '' };
       expect(PetMember.guard(petMember)).toBe(true);
+      expect(PetMember.guard(anotherMember)).toBe(false);
     });
   });
 });

--- a/src/types/record.spec.ts
+++ b/src/types/record.spec.ts
@@ -1,4 +1,7 @@
 import { Record, String, Static } from '..';
+import { Literal } from './literal';
+import { Number } from './number';
+import { Optional } from './optional';
 
 describe('record', () => {
   const CrewMember = Record({
@@ -36,6 +39,38 @@ describe('record', () => {
       const PetMember = CrewMember.omit();
       type PetMember = Static<typeof PetMember>;
       const petMember: PetMember = { name: '', home: '', rank: '' };
+      expect(Object.keys(PetMember.fields)).toEqual(['name', 'rank', 'home']);
+      expect(PetMember.guard(petMember)).toBe(true);
+    });
+  });
+
+  describe('extend', () => {
+    it('adds fields', () => {
+      const BaseShapeParams = Record({
+        x: Number,
+        y: Number,
+        width: Number,
+        height: Number,
+        rotation: Number,
+      });
+      const PolygonParams = BaseShapeParams.extend({
+        sides: Number,
+      });
+      expect(Object.keys(PolygonParams.fields)).toEqual([
+        'x',
+        'y',
+        'width',
+        'height',
+        'rotation',
+        'sides',
+      ]);
+    });
+    it('overwrites with a narrower type', () => {
+      // @ts-ignore
+      const WrongPetMember = CrewMember.extend({ name: Optional(String) });
+      const PetMember = CrewMember.extend({ name: Literal('pet') });
+      type PetMember = Static<typeof PetMember>;
+      const petMember: PetMember = { name: 'pet', home: '', rank: '' };
       expect(Object.keys(PetMember.fields)).toEqual(['name', 'rank', 'home']);
       expect(PetMember.guard(petMember)).toBe(true);
     });


### PR DESCRIPTION
Closes #238. `extends` is a reserved word in JS, so we use `extend` instead. The signature looks complicated like this:

```ts
  extend<P extends { [_: string]: RuntypeBase }>(
    fields: {
      [K in keyof P]: K extends keyof O
        ? Static<P[K]> extends Static<O[K]>
          ? P[K]
          : RuntypeBase<Static<O[K]>>
        : P[K];
    },
  ): InternalRecord<
    { [K in keyof (O & P)]: K extends keyof P ? P[K] : K extends keyof O ? O[K] : never },
    Part,
    RO
  >;
```

But `extend` allows you to overwrite fields with narrower runtypes. It emits a compile-time error if any field is not assignable to the base runtype.