### PR TITLE
Fix: handle `Never` properties in `Record`

### DIFF
--- a/src/types/record.spec.ts
+++ b/src/types/record.spec.ts
@@ -2,8 +2,19 @@ import { Record, String, Static } from '..';
 import { Literal } from './literal';
 import { Number } from './number';
 import { Optional } from './optional';
+import { Never } from './never';
 
 describe('record', () => {
+  it('should work with never properties', () => {
+    const R = Record({ foo: Never });
+    type R = Static<typeof R>;
+    // https://github.com/microsoft/TypeScript/issues/43954
+    // @ts-ignore
+    const r: R = {};
+    expect(R.guard({ foo: true })).toBe(false);
+    expect(R.guard(r)).toBe(true);
+  });
+
   const CrewMember = Record({
     name: String,
     rank: String,

--- a/src/types/record.ts
+++ b/src/types/record.ts
@@ -113,13 +113,16 @@ export function InternalRecord<
           const xHasKey = hasKey(key, x);
           if (fieldsHasKey) {
             const runtype = fields[key as any];
+            const isNever = runtype.reflect.tag === 'never';
             const isOptional = isPartial || runtype.reflect.tag === 'optional';
             if (xHasKey) {
               const value = x[key as any];
-              if (isOptional && value === undefined) results[key as any] = SUCCESS(value);
+              if (isNever) results[key as any] = FAILURE.PROPERTY_PRESENT(value);
+              else if (isOptional && value === undefined) results[key as any] = SUCCESS(value);
               else results[key as any] = innerValidate(runtype, value, visited);
             } else {
-              if (!isOptional) results[key as any] = FAILURE.PROPERTY_MISSING(runtype.reflect);
+              if (isNever) results[key as any] = SUCCESS(undefined);
+              else if (!isOptional) results[key as any] = FAILURE.PROPERTY_MISSING(runtype.reflect);
               else results[key as any] = SUCCESS(undefined);
             }
           } else if (xHasKey) {


### PR DESCRIPTION
This is an ahead-of-time implementation of #248. May not be merged depending on upstream decision.