### PR TITLE
Handle null prototypes in failure messaging

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -652,6 +652,15 @@ describe('check errors', () => {
       'Expected number | string, but was boolean',
     );
   });
+
+  it('union for null prototype', () => {
+    assertThrows(
+      Object.assign(Object.create(null)),
+      Union(Number, String),
+      Failcode.TYPE_INCORRECT,
+      'Expected number | string, but was object',
+    );
+  });
 });
 
 describe('reflection', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,9 +18,9 @@ export const typeOf = (value: unknown) =>
       ? 'null'
       : Array.isArray(value)
       ? 'array'
-      : value.constructor.name === 'Object'
+      : value.constructor?.name === 'Object'
       ? 'object'
-      : value.constructor.name
+      : value.constructor?.name ?? typeof value
     : typeof value;
 
 export const enumerableKeysOf = (object: unknown) =>


### PR DESCRIPTION
I missed this case in #227. It's possible to crash `Runtype.validate` here by passing in an object with a null prototype that _fails_ validation and triggers message generation via `typeOf`.

```
TypeError: Cannot read property 'name' of undefined
    at Object.typeOf (/workdir/node_modules/runtypes/lib/util.js:29:37)
    at Function.TYPE_INCORRECT (/workdir/node_modules/runtypes/lib/util.js:49:83)
    at /workdir/node_modules/runtypes/lib/types/union.js:127:31
    at Object.A._innerValidate (/workdir/node_modules/runtypes/lib/runtype.js:14:16)
    at Object.A.validate (/workdir/node_modules/runtypes/lib/runtype.js:16:46)
```