### PR TITLE
Add helper function `when` for top-level `match` function

### DIFF
--- a/src/match.spec.ts
+++ b/src/match.spec.ts
@@ -1,11 +1,12 @@
 import { Literal, String, Number, match } from '.';
+import { when } from './match';
 
 describe('match', () => {
   it('works', () => {
-    const f = match(
-      [Literal(42), fortyTwo => fortyTwo / 2],
-      [Number, n => n + 9],
-      [String, s => s.length * 2],
+    const f: (value: string | number) => number = match(
+      when(Literal(42), fortyTwo => fortyTwo / 2),
+      when(Number, n => n + 9),
+      when(String, s => s.length * 2),
     );
 
     expect(f(42)).toBe(21);

--- a/src/match.ts
+++ b/src/match.ts
@@ -1,4 +1,4 @@
-import { RuntypeBase } from './runtype';
+import { RuntypeBase, Static } from './runtype';
 import { Case, Matcher } from './types/union';
 
 export function match<A extends [PairCase<any, any>, ...PairCase<any, any>[]]>(
@@ -18,3 +18,10 @@ export function match<A extends [PairCase<any, any>, ...PairCase<any, any>[]]>(
 }
 
 export type PairCase<A extends RuntypeBase, Z> = [A, Case<A, Z>];
+
+export function when<A extends RuntypeBase<any>, B>(
+  runtype: A,
+  transformer: (value: Static<A>) => B,
+): PairCase<A, B> {
+  return [runtype, transformer];
+}


### PR DESCRIPTION
This provides a workaround for #259. I couldn't find a real “fix” for the type inference problem. AFAIK it seems to be impossible to infer the parameter types of the case functions in the inner tuples, so I desided to provide a new helper function to get it inferred, `when`, which will also lead us to more readable code:

```ts
const f = match(
  when(Literal(42), fortyTwo => fortyTwo / 2),
  when(Number, n => n + 9),
  when(String, s => s.length * 2),
);
```