### PR TITLE
Verbose validation error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "coveralls": "^3.1.0",
     "jest": "26.6.3",
     "jest-github-actions-reporter": "^1.0.3",
+    "outdent": "^0.8.0",
     "prettier": "^2.2.1",
     "ts-jest": "^26.5.4",
     "typescript": "4.5.2"

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -384,7 +384,11 @@ describe('check errors', () => {
       [false, '0', true],
       Tuple(Number, String, Boolean),
       Failcode.CONTENT_INCORRECT,
-      'Expected [number, string, boolean], but was incompatible',
+      `Validation failed:\n`+
+      `[\n`+
+      `  "Expected number, but was boolean"\n`+
+      `].\n`+
+      `Object should match [number, string, boolean]`,
       { 0: 'Expected number, but was boolean' },
     );
   });
@@ -403,7 +407,13 @@ describe('check errors', () => {
       [0, { name: 0 }],
       Tuple(Number, Record({ name: String })),
       Failcode.CONTENT_INCORRECT,
-      'Expected [number, { name: string; }], but was incompatible',
+      `Validation failed:\n`+
+      `[\n`+
+      `    {\n`+
+      `    "name": "Expected string, but was number"\n`+
+      `  }\n`+
+      `].\n`+
+      `Object should match [number, { name: string; }]`,
       { 1: { name: 'Expected string, but was number' } },
     );
   });
@@ -417,7 +427,11 @@ describe('check errors', () => {
       [0, 2, 'test'],
       Array(Number),
       Failcode.CONTENT_INCORRECT,
-      'Expected number[], but was incompatible',
+      `Validation failed:\n`+
+      `[\n`+
+      `      "Expected number, but was string"\n`+
+      `].\n`+
+      `Object should match number[]`,
       { 2: 'Expected number, but was string' },
     );
   });
@@ -427,7 +441,13 @@ describe('check errors', () => {
       [{ name: 'Foo' }, { name: false }],
       Array(Record({ name: String })),
       Failcode.CONTENT_INCORRECT,
-      'Expected { name: string; }[], but was incompatible',
+      `Validation failed:\n`+
+      `[\n`+
+      `    {\n`+
+      `    "name": "Expected string, but was boolean"\n`+
+      `  }\n`+
+      `].\n`+
+      `Object should match { name: string; }[]`,
       { 1: { name: 'Expected string, but was boolean' } },
     );
   });
@@ -437,7 +457,11 @@ describe('check errors', () => {
       [{ name: 'Foo' }, null],
       Array(Record({ name: String })),
       Failcode.CONTENT_INCORRECT,
-      'Expected { name: string; }[], but was incompatible',
+      `Validation failed:\n`+
+      `[\n`+
+      `    "Expected { name: string; }, but was null"\n`+
+      `].\n`+
+      `Object should match { name: string; }[]`,
       { 1: 'Expected { name: string; }, but was null' },
     );
   });
@@ -447,7 +471,11 @@ describe('check errors', () => {
       [0, 2, 'test'],
       Array(Number).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      'Expected readonly number[], but was incompatible',
+      `Validation failed:\n`+
+      `[\n`+
+      `      "Expected number, but was string"\n`+
+      `].\n`+
+      `Object should match readonly number[]`,
       { 2: 'Expected number, but was string' },
     );
   });
@@ -457,7 +485,13 @@ describe('check errors', () => {
       [{ name: 'Foo' }, { name: false }],
       Array(Record({ name: String })).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      'Expected readonly { name: string; }[], but was incompatible',
+      `Validation failed:\n`+
+      `[\n`+
+      `    {\n`+
+      `    "name": "Expected string, but was boolean"\n`+
+      `  }\n`+
+      `].\n`+
+      `Object should match readonly { name: string; }[]`,
       { 1: { name: 'Expected string, but was boolean' } },
     );
   });
@@ -467,7 +501,11 @@ describe('check errors', () => {
       [{ name: 'Foo' }, null],
       Array(Record({ name: String })).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      'Expected readonly { name: string; }[], but was incompatible',
+      `Validation failed:\n`+
+      `[\n`+
+      `    "Expected { name: string; }, but was null"\n`+
+      `].\n`+
+      `Object should match readonly { name: string; }[]`,
       { 1: 'Expected { name: string; }, but was null' },
     );
   });
@@ -501,7 +539,13 @@ describe('check errors', () => {
       { foo: { name: false } },
       Dictionary(Record({ name: String })),
       Failcode.CONTENT_INCORRECT,
-      'Expected { [_: string]: { name: string; } }, but was incompatible',
+      `Validation failed:\n`+
+      `{\n`+
+      `  "foo": {\n`+
+      `    "name": "Expected string, but was boolean"\n`+
+      `  }\n`+
+      `}.\n`+
+      `Object should match { [_: string]: { name: string; } }`,
       { foo: { name: 'Expected string, but was boolean' } },
     );
   });
@@ -511,7 +555,11 @@ describe('check errors', () => {
       { foo: 'bar', test: true },
       Dictionary(String),
       Failcode.CONTENT_INCORRECT,
-      'Expected { [_: string]: string }, but was incompatible',
+      `Validation failed:\n`+
+      `{\n`+
+      `  "test": "Expected string, but was boolean"\n`+
+      `}.\n`+
+      `Object should match { [_: string]: string }`,
       { test: 'Expected string, but was boolean' },
     );
   });
@@ -521,7 +569,11 @@ describe('check errors', () => {
       { 1: 'bar', 2: 20 },
       Dictionary(String, 'number'),
       Failcode.CONTENT_INCORRECT,
-      'Expected { [_: number]: string }, but was incompatible',
+      `Validation failed:\n`+
+      `{\n`+
+      `  "2": "Expected string, but was number"\n`+
+      `}.\n`+
+      `Object should match { [_: number]: string }`,
       { 2: 'Expected string, but was number' },
     );
   });
@@ -534,7 +586,11 @@ describe('check errors', () => {
         age: Number,
       }),
       Failcode.CONTENT_INCORRECT,
-      'Expected { name: string; age: number; }, but was incompatible',
+      `Validation failed:\n`+
+      `{\n`+
+      `  "age": "Expected number, but was string"\n`+
+      `}.\n`+
+      `Object should match { name: string; age: number; }`,
       { age: 'Expected number, but was string' },
     );
   });
@@ -559,7 +615,11 @@ describe('check errors', () => {
         age: Number,
       }),
       Failcode.CONTENT_INCORRECT,
-      'Expected { name: string; age: number; }, but was incompatible',
+      `Validation failed:\n`+
+      `{\n`+
+      `  "age": "Expected number, but was missing"\n`+
+      `}.\n`+
+      `Object should match { name: string; age: number; }`,
       { age: 'Expected number, but was missing' },
     );
   });
@@ -573,7 +633,15 @@ describe('check errors', () => {
         likes: Array(Record({ title: String })),
       }),
       Failcode.CONTENT_INCORRECT,
-      'Expected { name: string; age: number; likes: { title: string; }[]; }, but was incompatible',
+      `Validation failed:\n`+
+      `{\n`+
+      `  "likes": [\n`+
+      `    {\n`+
+      `      "title": "Expected string, but was boolean"\n`+
+      `    }\n`+
+      `  ]\n`+
+      `}.\n`+
+      `Object should match { name: string; age: number; likes: { title: string; }[]; }`,
       { likes: { 0: { title: 'Expected string, but was boolean' } } },
     );
   });
@@ -586,7 +654,11 @@ describe('check errors', () => {
         age: Number,
       }).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      'Expected { readonly name: string; readonly age: number; }, but was incompatible',
+      `Validation failed:\n`+
+      `{\n`+
+      `  "age": "Expected number, but was string"\n`+
+      `}.\n`+
+      `Object should match { readonly name: string; readonly age: number; }`,
       { age: 'Expected number, but was string' },
     );
   });
@@ -599,7 +671,11 @@ describe('check errors', () => {
         age: Number,
       }).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      'Expected { readonly name: string; readonly age: number; }, but was incompatible',
+      `Validation failed:\n`+
+      `{\n`+
+      `  "age": "Expected number, but was missing"\n`+
+      `}.\n`+
+      `Object should match { readonly name: string; readonly age: number; }`,
       { age: 'Expected number, but was missing' },
     );
   });
@@ -613,7 +689,15 @@ describe('check errors', () => {
         likes: Array(Record({ title: String }).asReadonly()),
       }).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      'Expected { readonly name: string; readonly age: number; readonly likes: { readonly title: string; }[]; }, but was incompatible',
+      `Validation failed:\n`+
+      `{\n`+
+      `  "likes": [\n`+
+      `    {\n`+
+      `      "title": "Expected string, but was boolean"\n`+
+      `    }\n`+
+      `  ]\n`+
+      `}.\n`+
+      `Object should match { readonly name: string; readonly age: number; readonly likes: { readonly title: string; }[]; }`,
       { likes: { 0: { title: 'Expected string, but was boolean' } } },
     );
   });
@@ -626,7 +710,11 @@ describe('check errors', () => {
         age: Number,
       }),
       Failcode.CONTENT_INCORRECT,
-      'Expected { name?: string; age?: number; }, but was incompatible',
+      `Validation failed:\n`+
+      `{\n`+
+      `  "age": "Expected number, but was null"\n`+
+      `}.\n`+
+      `Object should match { name?: string; age?: number; }`,
       { age: 'Expected number, but was null' },
     );
   });
@@ -640,7 +728,15 @@ describe('check errors', () => {
         likes: Array(Record({ title: String })),
       }),
       Failcode.CONTENT_INCORRECT,
-      'Expected { name?: string; age?: number; likes?: { title: string; }[]; }, but was incompatible',
+      `Validation failed:\n`+
+      `{\n`+
+      `  "likes": [\n`+
+      `    {\n`+
+      `      "title": "Expected string, but was number"\n`+
+      `    }\n`+
+      `  ]\n`+
+      `}.\n`+
+      `Object should match { name?: string; age?: number; likes?: { title: string; }[]; }`,
       { likes: { 0: { title: 'Expected string, but was number' } } },
     );
   });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -37,6 +37,8 @@ import { Constructor } from './types/instanceof';
 import { ValidationError } from './errors';
 import { Details, Failcode } from './result';
 
+import outdent from 'outdent';
+
 const boolTuple = Tuple(Boolean, Boolean, Boolean);
 const record1 = Record({ Boolean, Number });
 const union1 = Union(Literal(3), String, boolTuple, record1);
@@ -384,11 +386,13 @@ describe('check errors', () => {
       [false, '0', true],
       Tuple(Number, String, Boolean),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `[\n` +
-        `  "Expected number, but was boolean"\n` +
-        `].\n` +
-        `Object should match [number, string, boolean]`,
+      outdent`
+        Validation failed:
+        [
+          "Expected number, but was boolean"
+        ].
+        Object should match [number, string, boolean]
+      `,
       { 0: 'Expected number, but was boolean' },
     );
   });
@@ -407,13 +411,15 @@ describe('check errors', () => {
       [0, { name: 0 }],
       Tuple(Number, Record({ name: String })),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `[\n` +
-        `  {\n` +
-        `    "name": "Expected string, but was number"\n` +
-        `  }\n` +
-        `].\n` +
-        `Object should match [number, { name: string; }]`,
+      outdent`
+        Validation failed:
+        [
+          {
+            "name": "Expected string, but was number"
+          }
+        ].
+        Object should match [number, { name: string; }]
+      `,
       { 1: { name: 'Expected string, but was number' } },
     );
   });
@@ -427,11 +433,13 @@ describe('check errors', () => {
       [0, 2, 'test'],
       Array(Number),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `[\n` +
-        `  "Expected number, but was string"\n` +
-        `].\n` +
-        `Object should match number[]`,
+      outdent`
+        Validation failed:
+        [
+          "Expected number, but was string"
+        ].
+        Object should match number[]
+      `,
       { 2: 'Expected number, but was string' },
     );
   });
@@ -441,13 +449,15 @@ describe('check errors', () => {
       [{ name: 'Foo' }, { name: false }],
       Array(Record({ name: String })),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `[\n` +
-        `  {\n` +
-        `    "name": "Expected string, but was boolean"\n` +
-        `  }\n` +
-        `].\n` +
-        `Object should match { name: string; }[]`,
+      outdent`
+        Validation failed:
+        [
+          {
+            "name": "Expected string, but was boolean"
+          }
+        ].
+        Object should match { name: string; }[]
+      `,
       { 1: { name: 'Expected string, but was boolean' } },
     );
   });
@@ -457,11 +467,13 @@ describe('check errors', () => {
       [{ name: 'Foo' }, null],
       Array(Record({ name: String })),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `[\n` +
-        `  "Expected { name: string; }, but was null"\n` +
-        `].\n` +
-        `Object should match { name: string; }[]`,
+      outdent`
+        Validation failed:
+        [
+          "Expected { name: string; }, but was null"
+        ].
+        Object should match { name: string; }[]
+      `,
       { 1: 'Expected { name: string; }, but was null' },
     );
   });
@@ -471,11 +483,13 @@ describe('check errors', () => {
       [0, 2, 'test'],
       Array(Number).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `[\n` +
-        `  "Expected number, but was string"\n` +
-        `].\n` +
-        `Object should match readonly number[]`,
+      outdent`
+        Validation failed:
+        [
+          "Expected number, but was string"
+        ].
+        Object should match readonly number[]
+      `,
       { 2: 'Expected number, but was string' },
     );
   });
@@ -485,13 +499,15 @@ describe('check errors', () => {
       [{ name: 'Foo' }, { name: false }],
       Array(Record({ name: String })).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `[\n` +
-        `  {\n` +
-        `    "name": "Expected string, but was boolean"\n` +
-        `  }\n` +
-        `].\n` +
-        `Object should match readonly { name: string; }[]`,
+      outdent`
+        Validation failed:
+        [
+          {
+            "name": "Expected string, but was boolean"
+          }
+        ].
+        Object should match readonly { name: string; }[]
+      `,
       { 1: { name: 'Expected string, but was boolean' } },
     );
   });
@@ -501,11 +517,13 @@ describe('check errors', () => {
       [{ name: 'Foo' }, null],
       Array(Record({ name: String })).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `[\n` +
-        `  "Expected { name: string; }, but was null"\n` +
-        `].\n` +
-        `Object should match readonly { name: string; }[]`,
+      outdent`
+        Validation failed:
+        [
+          "Expected { name: string; }, but was null"
+        ].
+        Object should match readonly { name: string; }[]
+      `,
       { 1: 'Expected { name: string; }, but was null' },
     );
   });
@@ -539,13 +557,15 @@ describe('check errors', () => {
       { foo: { name: false } },
       Dictionary(Record({ name: String })),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `{\n` +
-        `  "foo": {\n` +
-        `    "name": "Expected string, but was boolean"\n` +
-        `  }\n` +
-        `}.\n` +
-        `Object should match { [_: string]: { name: string; } }`,
+      outdent`
+        Validation failed:
+        {
+          "foo": {
+            "name": "Expected string, but was boolean"
+          }
+        }.
+        Object should match { [_: string]: { name: string; } }
+      `,
       { foo: { name: 'Expected string, but was boolean' } },
     );
   });
@@ -555,11 +575,13 @@ describe('check errors', () => {
       { foo: 'bar', test: true },
       Dictionary(String),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `{\n` +
-        `  "test": "Expected string, but was boolean"\n` +
-        `}.\n` +
-        `Object should match { [_: string]: string }`,
+      outdent`
+        Validation failed:
+        {
+          "test": "Expected string, but was boolean"
+        }.
+        Object should match { [_: string]: string }
+      `,
       { test: 'Expected string, but was boolean' },
     );
   });
@@ -569,11 +591,13 @@ describe('check errors', () => {
       { 1: 'bar', 2: 20 },
       Dictionary(String, 'number'),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `{\n` +
-        `  "2": "Expected string, but was number"\n` +
-        `}.\n` +
-        `Object should match { [_: number]: string }`,
+      outdent`
+        Validation failed:
+        {
+          "2": "Expected string, but was number"
+        }.
+        Object should match { [_: number]: string }
+      `,
       { 2: 'Expected string, but was number' },
     );
   });
@@ -586,11 +610,13 @@ describe('check errors', () => {
         age: Number,
       }),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `{\n` +
-        `  "age": "Expected number, but was string"\n` +
-        `}.\n` +
-        `Object should match { name: string; age: number; }`,
+      outdent`
+        Validation failed:
+        {
+          "age": "Expected number, but was string"
+        }.
+        Object should match { name: string; age: number; }
+      `,
       { age: 'Expected number, but was string' },
     );
   });
@@ -615,11 +641,13 @@ describe('check errors', () => {
         age: Number,
       }),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `{\n` +
-        `  "age": "Expected number, but was missing"\n` +
-        `}.\n` +
-        `Object should match { name: string; age: number; }`,
+      outdent`
+        Validation failed:
+        {
+          "age": "Expected number, but was missing"
+        }.
+        Object should match { name: string; age: number; }
+      `,
       { age: 'Expected number, but was missing' },
     );
   });
@@ -633,15 +661,17 @@ describe('check errors', () => {
         likes: Array(Record({ title: String })),
       }),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `{\n` +
-        `  "likes": [\n` +
-        `    {\n` +
-        `      "title": "Expected string, but was boolean"\n` +
-        `    }\n` +
-        `  ]\n` +
-        `}.\n` +
-        `Object should match { name: string; age: number; likes: { title: string; }[]; }`,
+      outdent`
+        Validation failed:
+        {
+          "likes": [
+            {
+              "title": "Expected string, but was boolean"
+            }
+          ]
+        }.
+        Object should match { name: string; age: number; likes: { title: string; }[]; }
+      `,
       { likes: { 0: { title: 'Expected string, but was boolean' } } },
     );
   });
@@ -654,11 +684,13 @@ describe('check errors', () => {
         age: Number,
       }).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `{\n` +
-        `  "age": "Expected number, but was string"\n` +
-        `}.\n` +
-        `Object should match { readonly name: string; readonly age: number; }`,
+      outdent`
+        Validation failed:
+        {
+          "age": "Expected number, but was string"
+        }.
+        Object should match { readonly name: string; readonly age: number; }
+      `,
       { age: 'Expected number, but was string' },
     );
   });
@@ -671,11 +703,13 @@ describe('check errors', () => {
         age: Number,
       }).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `{\n` +
-        `  "age": "Expected number, but was missing"\n` +
-        `}.\n` +
-        `Object should match { readonly name: string; readonly age: number; }`,
+      outdent`
+        Validation failed:
+        {
+          "age": "Expected number, but was missing"
+        }.
+        Object should match { readonly name: string; readonly age: number; }
+      `,
       { age: 'Expected number, but was missing' },
     );
   });
@@ -689,15 +723,17 @@ describe('check errors', () => {
         likes: Array(Record({ title: String }).asReadonly()),
       }).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `{\n` +
-        `  "likes": [\n` +
-        `    {\n` +
-        `      "title": "Expected string, but was boolean"\n` +
-        `    }\n` +
-        `  ]\n` +
-        `}.\n` +
-        `Object should match { readonly name: string; readonly age: number; readonly likes: { readonly title: string; }[]; }`,
+      outdent`
+        Validation failed:
+        {
+          "likes": [
+            {
+              "title": "Expected string, but was boolean"
+            }
+          ]
+        }.
+        Object should match { readonly name: string; readonly age: number; readonly likes: { readonly title: string; }[]; }
+      `,
       { likes: { 0: { title: 'Expected string, but was boolean' } } },
     );
   });
@@ -710,11 +746,13 @@ describe('check errors', () => {
         age: Number,
       }),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `{\n` +
-        `  "age": "Expected number, but was null"\n` +
-        `}.\n` +
-        `Object should match { name?: string; age?: number; }`,
+      outdent`
+        Validation failed:
+        {
+          "age": "Expected number, but was null"
+        }.
+        Object should match { name?: string; age?: number; }
+      `,
       { age: 'Expected number, but was null' },
     );
   });
@@ -728,15 +766,17 @@ describe('check errors', () => {
         likes: Array(Record({ title: String })),
       }),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n` +
-        `{\n` +
-        `  "likes": [\n` +
-        `    {\n` +
-        `      "title": "Expected string, but was number"\n` +
-        `    }\n` +
-        `  ]\n` +
-        `}.\n` +
-        `Object should match { name?: string; age?: number; likes?: { title: string; }[]; }`,
+      outdent`
+        Validation failed:
+        {
+          "likes": [
+            {
+              "title": "Expected string, but was number"
+            }
+          ]
+        }.
+        Object should match { name?: string; age?: number; likes?: { title: string; }[]; }
+      `,
       { likes: { 0: { title: 'Expected string, but was number' } } },
     );
   });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -384,11 +384,11 @@ describe('check errors', () => {
       [false, '0', true],
       Tuple(Number, String, Boolean),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `[\n`+
-      `  "Expected number, but was boolean"\n`+
-      `].\n`+
-      `Object should match [number, string, boolean]`,
+      `Validation failed:\n` +
+        `[\n` +
+        `  "Expected number, but was boolean"\n` +
+        `].\n` +
+        `Object should match [number, string, boolean]`,
       { 0: 'Expected number, but was boolean' },
     );
   });
@@ -407,13 +407,13 @@ describe('check errors', () => {
       [0, { name: 0 }],
       Tuple(Number, Record({ name: String })),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `[\n`+
-      `    {\n`+
-      `    "name": "Expected string, but was number"\n`+
-      `  }\n`+
-      `].\n`+
-      `Object should match [number, { name: string; }]`,
+      `Validation failed:\n` +
+        `[\n` +
+        `    {\n` +
+        `    "name": "Expected string, but was number"\n` +
+        `  }\n` +
+        `].\n` +
+        `Object should match [number, { name: string; }]`,
       { 1: { name: 'Expected string, but was number' } },
     );
   });
@@ -427,11 +427,11 @@ describe('check errors', () => {
       [0, 2, 'test'],
       Array(Number),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `[\n`+
-      `      "Expected number, but was string"\n`+
-      `].\n`+
-      `Object should match number[]`,
+      `Validation failed:\n` +
+        `[\n` +
+        `      "Expected number, but was string"\n` +
+        `].\n` +
+        `Object should match number[]`,
       { 2: 'Expected number, but was string' },
     );
   });
@@ -441,13 +441,13 @@ describe('check errors', () => {
       [{ name: 'Foo' }, { name: false }],
       Array(Record({ name: String })),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `[\n`+
-      `    {\n`+
-      `    "name": "Expected string, but was boolean"\n`+
-      `  }\n`+
-      `].\n`+
-      `Object should match { name: string; }[]`,
+      `Validation failed:\n` +
+        `[\n` +
+        `    {\n` +
+        `    "name": "Expected string, but was boolean"\n` +
+        `  }\n` +
+        `].\n` +
+        `Object should match { name: string; }[]`,
       { 1: { name: 'Expected string, but was boolean' } },
     );
   });
@@ -457,11 +457,11 @@ describe('check errors', () => {
       [{ name: 'Foo' }, null],
       Array(Record({ name: String })),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `[\n`+
-      `    "Expected { name: string; }, but was null"\n`+
-      `].\n`+
-      `Object should match { name: string; }[]`,
+      `Validation failed:\n` +
+        `[\n` +
+        `    "Expected { name: string; }, but was null"\n` +
+        `].\n` +
+        `Object should match { name: string; }[]`,
       { 1: 'Expected { name: string; }, but was null' },
     );
   });
@@ -471,11 +471,11 @@ describe('check errors', () => {
       [0, 2, 'test'],
       Array(Number).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `[\n`+
-      `      "Expected number, but was string"\n`+
-      `].\n`+
-      `Object should match readonly number[]`,
+      `Validation failed:\n` +
+        `[\n` +
+        `      "Expected number, but was string"\n` +
+        `].\n` +
+        `Object should match readonly number[]`,
       { 2: 'Expected number, but was string' },
     );
   });
@@ -485,13 +485,13 @@ describe('check errors', () => {
       [{ name: 'Foo' }, { name: false }],
       Array(Record({ name: String })).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `[\n`+
-      `    {\n`+
-      `    "name": "Expected string, but was boolean"\n`+
-      `  }\n`+
-      `].\n`+
-      `Object should match readonly { name: string; }[]`,
+      `Validation failed:\n` +
+        `[\n` +
+        `    {\n` +
+        `    "name": "Expected string, but was boolean"\n` +
+        `  }\n` +
+        `].\n` +
+        `Object should match readonly { name: string; }[]`,
       { 1: { name: 'Expected string, but was boolean' } },
     );
   });
@@ -501,11 +501,11 @@ describe('check errors', () => {
       [{ name: 'Foo' }, null],
       Array(Record({ name: String })).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `[\n`+
-      `    "Expected { name: string; }, but was null"\n`+
-      `].\n`+
-      `Object should match readonly { name: string; }[]`,
+      `Validation failed:\n` +
+        `[\n` +
+        `    "Expected { name: string; }, but was null"\n` +
+        `].\n` +
+        `Object should match readonly { name: string; }[]`,
       { 1: 'Expected { name: string; }, but was null' },
     );
   });
@@ -539,13 +539,13 @@ describe('check errors', () => {
       { foo: { name: false } },
       Dictionary(Record({ name: String })),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `{\n`+
-      `  "foo": {\n`+
-      `    "name": "Expected string, but was boolean"\n`+
-      `  }\n`+
-      `}.\n`+
-      `Object should match { [_: string]: { name: string; } }`,
+      `Validation failed:\n` +
+        `{\n` +
+        `  "foo": {\n` +
+        `    "name": "Expected string, but was boolean"\n` +
+        `  }\n` +
+        `}.\n` +
+        `Object should match { [_: string]: { name: string; } }`,
       { foo: { name: 'Expected string, but was boolean' } },
     );
   });
@@ -555,11 +555,11 @@ describe('check errors', () => {
       { foo: 'bar', test: true },
       Dictionary(String),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `{\n`+
-      `  "test": "Expected string, but was boolean"\n`+
-      `}.\n`+
-      `Object should match { [_: string]: string }`,
+      `Validation failed:\n` +
+        `{\n` +
+        `  "test": "Expected string, but was boolean"\n` +
+        `}.\n` +
+        `Object should match { [_: string]: string }`,
       { test: 'Expected string, but was boolean' },
     );
   });
@@ -569,11 +569,11 @@ describe('check errors', () => {
       { 1: 'bar', 2: 20 },
       Dictionary(String, 'number'),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `{\n`+
-      `  "2": "Expected string, but was number"\n`+
-      `}.\n`+
-      `Object should match { [_: number]: string }`,
+      `Validation failed:\n` +
+        `{\n` +
+        `  "2": "Expected string, but was number"\n` +
+        `}.\n` +
+        `Object should match { [_: number]: string }`,
       { 2: 'Expected string, but was number' },
     );
   });
@@ -586,11 +586,11 @@ describe('check errors', () => {
         age: Number,
       }),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `{\n`+
-      `  "age": "Expected number, but was string"\n`+
-      `}.\n`+
-      `Object should match { name: string; age: number; }`,
+      `Validation failed:\n` +
+        `{\n` +
+        `  "age": "Expected number, but was string"\n` +
+        `}.\n` +
+        `Object should match { name: string; age: number; }`,
       { age: 'Expected number, but was string' },
     );
   });
@@ -615,11 +615,11 @@ describe('check errors', () => {
         age: Number,
       }),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `{\n`+
-      `  "age": "Expected number, but was missing"\n`+
-      `}.\n`+
-      `Object should match { name: string; age: number; }`,
+      `Validation failed:\n` +
+        `{\n` +
+        `  "age": "Expected number, but was missing"\n` +
+        `}.\n` +
+        `Object should match { name: string; age: number; }`,
       { age: 'Expected number, but was missing' },
     );
   });
@@ -633,15 +633,15 @@ describe('check errors', () => {
         likes: Array(Record({ title: String })),
       }),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `{\n`+
-      `  "likes": [\n`+
-      `    {\n`+
-      `      "title": "Expected string, but was boolean"\n`+
-      `    }\n`+
-      `  ]\n`+
-      `}.\n`+
-      `Object should match { name: string; age: number; likes: { title: string; }[]; }`,
+      `Validation failed:\n` +
+        `{\n` +
+        `  "likes": [\n` +
+        `    {\n` +
+        `      "title": "Expected string, but was boolean"\n` +
+        `    }\n` +
+        `  ]\n` +
+        `}.\n` +
+        `Object should match { name: string; age: number; likes: { title: string; }[]; }`,
       { likes: { 0: { title: 'Expected string, but was boolean' } } },
     );
   });
@@ -654,11 +654,11 @@ describe('check errors', () => {
         age: Number,
       }).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `{\n`+
-      `  "age": "Expected number, but was string"\n`+
-      `}.\n`+
-      `Object should match { readonly name: string; readonly age: number; }`,
+      `Validation failed:\n` +
+        `{\n` +
+        `  "age": "Expected number, but was string"\n` +
+        `}.\n` +
+        `Object should match { readonly name: string; readonly age: number; }`,
       { age: 'Expected number, but was string' },
     );
   });
@@ -671,11 +671,11 @@ describe('check errors', () => {
         age: Number,
       }).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `{\n`+
-      `  "age": "Expected number, but was missing"\n`+
-      `}.\n`+
-      `Object should match { readonly name: string; readonly age: number; }`,
+      `Validation failed:\n` +
+        `{\n` +
+        `  "age": "Expected number, but was missing"\n` +
+        `}.\n` +
+        `Object should match { readonly name: string; readonly age: number; }`,
       { age: 'Expected number, but was missing' },
     );
   });
@@ -689,15 +689,15 @@ describe('check errors', () => {
         likes: Array(Record({ title: String }).asReadonly()),
       }).asReadonly(),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `{\n`+
-      `  "likes": [\n`+
-      `    {\n`+
-      `      "title": "Expected string, but was boolean"\n`+
-      `    }\n`+
-      `  ]\n`+
-      `}.\n`+
-      `Object should match { readonly name: string; readonly age: number; readonly likes: { readonly title: string; }[]; }`,
+      `Validation failed:\n` +
+        `{\n` +
+        `  "likes": [\n` +
+        `    {\n` +
+        `      "title": "Expected string, but was boolean"\n` +
+        `    }\n` +
+        `  ]\n` +
+        `}.\n` +
+        `Object should match { readonly name: string; readonly age: number; readonly likes: { readonly title: string; }[]; }`,
       { likes: { 0: { title: 'Expected string, but was boolean' } } },
     );
   });
@@ -710,11 +710,11 @@ describe('check errors', () => {
         age: Number,
       }),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `{\n`+
-      `  "age": "Expected number, but was null"\n`+
-      `}.\n`+
-      `Object should match { name?: string; age?: number; }`,
+      `Validation failed:\n` +
+        `{\n` +
+        `  "age": "Expected number, but was null"\n` +
+        `}.\n` +
+        `Object should match { name?: string; age?: number; }`,
       { age: 'Expected number, but was null' },
     );
   });
@@ -728,15 +728,15 @@ describe('check errors', () => {
         likes: Array(Record({ title: String })),
       }),
       Failcode.CONTENT_INCORRECT,
-      `Validation failed:\n`+
-      `{\n`+
-      `  "likes": [\n`+
-      `    {\n`+
-      `      "title": "Expected string, but was number"\n`+
-      `    }\n`+
-      `  ]\n`+
-      `}.\n`+
-      `Object should match { name?: string; age?: number; likes?: { title: string; }[]; }`,
+      `Validation failed:\n` +
+        `{\n` +
+        `  "likes": [\n` +
+        `    {\n` +
+        `      "title": "Expected string, but was number"\n` +
+        `    }\n` +
+        `  ]\n` +
+        `}.\n` +
+        `Object should match { name?: string; age?: number; likes?: { title: string; }[]; }`,
       { likes: { 0: { title: 'Expected string, but was number' } } },
     );
   });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -409,7 +409,7 @@ describe('check errors', () => {
       Failcode.CONTENT_INCORRECT,
       `Validation failed:\n` +
         `[\n` +
-        `    {\n` +
+        `  {\n` +
         `    "name": "Expected string, but was number"\n` +
         `  }\n` +
         `].\n` +
@@ -429,7 +429,7 @@ describe('check errors', () => {
       Failcode.CONTENT_INCORRECT,
       `Validation failed:\n` +
         `[\n` +
-        `      "Expected number, but was string"\n` +
+        `  "Expected number, but was string"\n` +
         `].\n` +
         `Object should match number[]`,
       { 2: 'Expected number, but was string' },
@@ -443,7 +443,7 @@ describe('check errors', () => {
       Failcode.CONTENT_INCORRECT,
       `Validation failed:\n` +
         `[\n` +
-        `    {\n` +
+        `  {\n` +
         `    "name": "Expected string, but was boolean"\n` +
         `  }\n` +
         `].\n` +
@@ -459,7 +459,7 @@ describe('check errors', () => {
       Failcode.CONTENT_INCORRECT,
       `Validation failed:\n` +
         `[\n` +
-        `    "Expected { name: string; }, but was null"\n` +
+        `  "Expected { name: string; }, but was null"\n` +
         `].\n` +
         `Object should match { name: string; }[]`,
       { 1: 'Expected { name: string; }, but was null' },
@@ -473,7 +473,7 @@ describe('check errors', () => {
       Failcode.CONTENT_INCORRECT,
       `Validation failed:\n` +
         `[\n` +
-        `      "Expected number, but was string"\n` +
+        `  "Expected number, but was string"\n` +
         `].\n` +
         `Object should match readonly number[]`,
       { 2: 'Expected number, but was string' },
@@ -487,7 +487,7 @@ describe('check errors', () => {
       Failcode.CONTENT_INCORRECT,
       `Validation failed:\n` +
         `[\n` +
-        `    {\n` +
+        `  {\n` +
         `    "name": "Expected string, but was boolean"\n` +
         `  }\n` +
         `].\n` +
@@ -503,7 +503,7 @@ describe('check errors', () => {
       Failcode.CONTENT_INCORRECT,
       `Validation failed:\n` +
         `[\n` +
-        `    "Expected { name: string; }, but was null"\n` +
+        `  "Expected { name: string; }, but was null"\n` +
         `].\n` +
         `Object should match readonly { name: string; }[]`,
       { 1: 'Expected { name: string; }, but was null' },

--- a/src/types/union.spec.ts
+++ b/src/types/union.spec.ts
@@ -48,15 +48,23 @@ describe('union', () => {
       expect(Shape.validate({ kind: 'square', size: new Date() })).toMatchObject({
         success: false,
         code: Failcode.CONTENT_INCORRECT,
-        message: 'Expected { kind: "square"; size: number; }, but was incompatible',
+        message: `Validation failed:\n`+
+        `{\n`+
+        `  \"size\": \"Expected number, but was Date\"\n`+
+        `}.\n`+
+        `Object should match { kind: \"square\"; size: number; }`,
         details: { size: 'Expected number, but was Date' },
       });
 
       expect(Shape.validate({ kind: 'rectangle', size: new Date() })).toMatchObject({
         success: false,
         code: Failcode.CONTENT_INCORRECT,
-        message:
-          'Expected { kind: "rectangle"; width: number; height: number; }, but was incompatible',
+        message: `Validation failed:\n`+
+        `{\n`+
+        `  \"width\": \"Expected number, but was missing\",\n`+
+        `  \"height\": \"Expected number, but was missing\"\n`+
+        `}.\n`+
+        `Object should match { kind: "rectangle"; width: number; height: number; }`,
         details: {
           width: 'Expected number, but was missing',
           height: 'Expected number, but was missing',
@@ -66,7 +74,11 @@ describe('union', () => {
       expect(Shape.validate({ kind: 'circle', size: new Date() })).toMatchObject({
         success: false,
         code: Failcode.CONTENT_INCORRECT,
-        message: 'Expected { kind: "circle"; radius: number; }, but was incompatible',
+        message: `Validation failed:\n`+
+        `{\n`+
+        `  \"radius\": \"Expected number, but was missing\"\n`+
+        `}.\n`+
+        `Object should match { kind: "circle"; radius: number; }`,
         details: { radius: 'Expected number, but was missing' },
       });
 

--- a/src/types/union.spec.ts
+++ b/src/types/union.spec.ts
@@ -2,6 +2,7 @@ import { Union, String, Literal, Record, Number, InstanceOf } from '..';
 import { Failcode } from '../result';
 import { Static } from '../runtype';
 import { LiteralBase } from './literal';
+import outdent from 'outdent';
 
 const ThreeOrString = Union(Literal(3), String);
 
@@ -48,25 +49,27 @@ describe('union', () => {
       expect(Shape.validate({ kind: 'square', size: new Date() })).toMatchObject({
         success: false,
         code: Failcode.CONTENT_INCORRECT,
-        message:
-          `Validation failed:\n` +
-          `{\n` +
-          `  \"size\": \"Expected number, but was Date\"\n` +
-          `}.\n` +
-          `Object should match { kind: \"square\"; size: number; }`,
+        message: outdent`
+          Validation failed:
+          {
+            \"size\": \"Expected number, but was Date\"
+          }.
+          Object should match { kind: \"square\"; size: number; }
+        `,
         details: { size: 'Expected number, but was Date' },
       });
 
       expect(Shape.validate({ kind: 'rectangle', size: new Date() })).toMatchObject({
         success: false,
         code: Failcode.CONTENT_INCORRECT,
-        message:
-          `Validation failed:\n` +
-          `{\n` +
-          `  \"width\": \"Expected number, but was missing\",\n` +
-          `  \"height\": \"Expected number, but was missing\"\n` +
-          `}.\n` +
-          `Object should match { kind: "rectangle"; width: number; height: number; }`,
+        message: outdent`
+          Validation failed:
+          {
+            \"width\": \"Expected number, but was missing\",
+            \"height\": \"Expected number, but was missing\"
+          }.
+          Object should match { kind: "rectangle"; width: number; height: number; }
+        `,
         details: {
           width: 'Expected number, but was missing',
           height: 'Expected number, but was missing',
@@ -76,12 +79,13 @@ describe('union', () => {
       expect(Shape.validate({ kind: 'circle', size: new Date() })).toMatchObject({
         success: false,
         code: Failcode.CONTENT_INCORRECT,
-        message:
-          `Validation failed:\n` +
-          `{\n` +
-          `  \"radius\": \"Expected number, but was missing\"\n` +
-          `}.\n` +
-          `Object should match { kind: "circle"; radius: number; }`,
+        message: outdent`
+          Validation failed:
+          {
+            \"radius\": \"Expected number, but was missing\"
+          }.
+          Object should match { kind: "circle"; radius: number; }
+        `,
         details: { radius: 'Expected number, but was missing' },
       });
 

--- a/src/types/union.spec.ts
+++ b/src/types/union.spec.ts
@@ -48,23 +48,25 @@ describe('union', () => {
       expect(Shape.validate({ kind: 'square', size: new Date() })).toMatchObject({
         success: false,
         code: Failcode.CONTENT_INCORRECT,
-        message: `Validation failed:\n`+
-        `{\n`+
-        `  \"size\": \"Expected number, but was Date\"\n`+
-        `}.\n`+
-        `Object should match { kind: \"square\"; size: number; }`,
+        message:
+          `Validation failed:\n` +
+          `{\n` +
+          `  \"size\": \"Expected number, but was Date\"\n` +
+          `}.\n` +
+          `Object should match { kind: \"square\"; size: number; }`,
         details: { size: 'Expected number, but was Date' },
       });
 
       expect(Shape.validate({ kind: 'rectangle', size: new Date() })).toMatchObject({
         success: false,
         code: Failcode.CONTENT_INCORRECT,
-        message: `Validation failed:\n`+
-        `{\n`+
-        `  \"width\": \"Expected number, but was missing\",\n`+
-        `  \"height\": \"Expected number, but was missing\"\n`+
-        `}.\n`+
-        `Object should match { kind: "rectangle"; width: number; height: number; }`,
+        message:
+          `Validation failed:\n` +
+          `{\n` +
+          `  \"width\": \"Expected number, but was missing\",\n` +
+          `  \"height\": \"Expected number, but was missing\"\n` +
+          `}.\n` +
+          `Object should match { kind: "rectangle"; width: number; height: number; }`,
         details: {
           width: 'Expected number, but was missing',
           height: 'Expected number, but was missing',
@@ -74,11 +76,12 @@ describe('union', () => {
       expect(Shape.validate({ kind: 'circle', size: new Date() })).toMatchObject({
         success: false,
         code: Failcode.CONTENT_INCORRECT,
-        message: `Validation failed:\n`+
-        `{\n`+
-        `  \"radius\": \"Expected number, but was missing\"\n`+
-        `}.\n`+
-        `Object should match { kind: "circle"; radius: number; }`,
+        message:
+          `Validation failed:\n` +
+          `{\n` +
+          `  \"radius\": \"Expected number, but was missing\"\n` +
+          `}.\n` +
+          `Object should match { kind: "circle"; radius: number; }`,
         details: { radius: 'Expected number, but was missing' },
       });
 

--- a/src/types/union.spec.ts
+++ b/src/types/union.spec.ts
@@ -52,9 +52,9 @@ describe('union', () => {
         message: outdent`
           Validation failed:
           {
-            \"size\": \"Expected number, but was Date\"
+            "size": "Expected number, but was Date"
           }.
-          Object should match { kind: \"square\"; size: number; }
+          Object should match { kind: "square"; size: number; }
         `,
         details: { size: 'Expected number, but was Date' },
       });
@@ -65,8 +65,8 @@ describe('union', () => {
         message: outdent`
           Validation failed:
           {
-            \"width\": \"Expected number, but was missing\",
-            \"height\": \"Expected number, but was missing\"
+            "width": "Expected number, but was missing",
+            "height": "Expected number, but was missing"
           }.
           Object should match { kind: "rectangle"; width: number; height: number; }
         `,
@@ -82,7 +82,7 @@ describe('union', () => {
         message: outdent`
           Validation failed:
           {
-            \"radius\": \"Expected number, but was missing\"
+            "radius": "Expected number, but was missing"
           }.
           Object should match { kind: "circle"; radius: number; }
         `,

--- a/src/util.ts
+++ b/src/util.ts
@@ -60,7 +60,7 @@ export const FAILURE = Object.assign(
       );
     },
     CONTENT_INCORRECT: (self: Reflect, details: Details) => {
-      const formattedDetails = JSON.stringify(details, null, 2).replace(/null,\n/g, '')
+      const formattedDetails = JSON.stringify(details, null, 2).replace(/null,\n/g, '');
       const message = `Validation failed:\n${formattedDetails}.\nObject should match ${show(self)}`;
       return FAILURE(Failcode.CONTENT_INCORRECT, message, details);
     },

--- a/src/util.ts
+++ b/src/util.ts
@@ -60,7 +60,7 @@ export const FAILURE = Object.assign(
       );
     },
     CONTENT_INCORRECT: (self: Reflect, details: Details) => {
-      const formattedDetails = JSON.stringify(details, null, 2).replace(/null,\n/g, '');
+      const formattedDetails = JSON.stringify(details, null, 2).replace(/^ *null,\n/gm, '');
       const message = `Validation failed:\n${formattedDetails}.\nObject should match ${show(self)}`;
       return FAILURE(Failcode.CONTENT_INCORRECT, message, details);
     },

--- a/src/util.ts
+++ b/src/util.ts
@@ -60,7 +60,8 @@ export const FAILURE = Object.assign(
       );
     },
     CONTENT_INCORRECT: (self: Reflect, details: Details) => {
-      const message = `Expected ${show(self)}, but was incompatible`;
+      const formattedDetails = JSON.stringify(details, null, 2).replace(/null,\n/g, '')
+      const message = `Validation failed:\n${formattedDetails}.\nObject should match ${show(self)}`;
       return FAILURE(Failcode.CONTENT_INCORRECT, message, details);
     },
     ARGUMENT_INCORRECT: (message: string) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2696,6 +2696,11 @@ optionator@^0.8.1:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
+outdent@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/outdent/-/outdent-0.8.0.tgz#2ebc3e77bf49912543f1008100ff8e7f44428eb0"
+  integrity sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==
+
 p-each-series@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-2.2.0.tgz#105ab0357ce72b202a8a8b94933672657b5e2a9a"


### PR DESCRIPTION
This PR addresses https://github.com/pelotom/runtypes/issues/260 - validation error messages should surface the incorrect fields without requiring extra error handling. 

Previously:
`Expected [number, { name: string; }], but was incompatible`

Now:
```
Validation failed:
[
  {
    "name": "Expected string, but was number"
  }
].
Object should match [number, { name: string; }]
```