### PR TITLE
fix: correct spelling for 'required' in brand example

### DIFF
--- a/examples/brand/index.ts
+++ b/examples/brand/index.ts
@@ -6,11 +6,14 @@ export type ID = Static<typeof ID>;
 export const ArrayNonEmpty = <T extends Runtype>(element: T) =>
   Array(element).withConstraint(a => 0 < a.length || 'array must not be empty');
 
-export const IDRequiedAndOptional = Record({ required: ArrayNonEmpty(ID) })
+export const IDRequiredAndOptional = Record({ required: ArrayNonEmpty(ID) })
   .And(Partial({ optional: ArrayNonEmpty(ID) }))
   .withBrand('IDRequiedAndOptional');
-export type IDRequiedAndOptional = Static<typeof IDRequiedAndOptional>;
+export type IDRequiedAndOptional = Static<typeof IDRequiredAndOptional>;
 
-const test: IDRequiedAndOptional = IDRequiedAndOptional.check({ required: ['a'], optional: ['b'] });
+const test: IDRequiedAndOptional = IDRequiredAndOptional.check({
+  required: ['a'],
+  optional: ['b'],
+});
 
-export default IDRequiedAndOptional;
+export default IDRequiredAndOptional;


### PR DESCRIPTION
Hey there! I just noticed that `required` was not spelled correctly in the `brand` example, so I thought I'd submit a PR to fix this. Cheers!