### PR TITLE
fix: validate sparse arrays without throwing

### DIFF
--- a/src/Array.test.ts
+++ b/src/Array.test.ts
@@ -74,6 +74,33 @@ Deno.test("Array", async t => {
 		})
 	})
 
+	await t.step("sparse array", async t => {
+		// A hole is non-enumerable, so a sparse array must validate its present
+		// elements without crashing.
+		const array: number[] = [0]
+		array[2] = 2
+		assert(Array(Number).guard(array))
+	})
+
+	await t.step("sparse array with failure", async t => {
+		const array: unknown[] = [0]
+		array[2] = "test"
+		const error = assertThrows(() => Array(Number).check(array))
+		assertInstanceOf(error, ValidationError)
+		assertObjectMatch(error, {
+			name: "ValidationError",
+			message: "Expected number[], but was incompatible",
+			failure: {
+				code: Failcode.CONTENT_INCORRECT,
+				details: {
+					2: {
+						code: Failcode.TYPE_INCORRECT,
+					},
+				},
+			},
+		})
+	})
+
 	await t.step("readonly array", async t => {
 		const error = assertThrows(() => Array(Number).asReadonly().check([0, 2, "test"]))
 		assertInstanceOf(error, ValidationError)

--- a/src/Array.ts
+++ b/src/Array.ts
@@ -48,9 +48,11 @@ const Array = <R extends Runtype.Core>(element: R): Array<R> => {
 			innerValidate({ expected: element, received: received[key], parsing }),
 		)
 		const details: globalThis.Record<number, Failure> = {}
-		for (const key of keys) {
+		for (let index = 0; index < keys.length; index++) {
 			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-			const result = results[key]!
+			const key = keys[index]!
+			// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+			const result = results[index]!
 			if (!result.success) details[key] = result
 		}
 


### PR DESCRIPTION
### Problem

`Array(T)` throws a `TypeError` on any sparse array, for every method:

```ts
import { Array, Number } from "runtypes"

const arr = [0]
arr[2] = 2 // [ 0, <hole>, 2 ]

Array(Number).guard(arr)
// TypeError: Cannot read properties of undefined (reading 'success')
```

### Cause

The element results are built positionally with `keys.map(...)`, but read back by the original array index:

```ts
const keys = enumerableKeysOf(received).filter(isNumberLikeKey) // ["0", "2"]
const results = keys.map(key => innerValidate(...))             // length 2

for (const key of keys) {
  const result = results[key]! // results["2"] is undefined for a sparse array
  ...
}
```

For a dense array the index always equals the position, so this happens to work. A sparse array's holes are non-enumerable, so `keys` skips index `1`; `keys` and `results` then fall out of sync, `results["2"]` is `undefined`, and the non-null assertion throws.

`Tuple` reads its results by position and `Record` keys them by the actual key, so `Array` is the only container with this mismatch.

### Fix

Iterate by position the way `Tuple` does, while keeping `details` keyed by the original index. Dense arrays are unchanged; a sparse array now validates its present elements, and a failing element is still reported under its real index.

Added two regression tests covering a valid and a failing sparse array.
