### PR TITLE
fix: enforce a bare literal `Record` key

### DIFF
--- a/src/Record.test.ts
+++ b/src/Record.test.ts
@@ -33,6 +33,40 @@ Deno.test("Record", async t => {
 		})
 	})
 
+	await t.step("should enforce a bare literal key", async t => {
+		const Dict = Record(Literal("a"), Number)
+		assertEquals(Dict.guard({}), false)
+		const error = assertThrows(() => Dict.check({}))
+		assertInstanceOf(error, ValidationError)
+		assertObjectMatch(error, {
+			failure: {
+				code: Failcode.CONTENT_INCORRECT,
+				details: {
+					a: {
+						code: Failcode.PROPERTY_MISSING,
+					},
+				},
+			},
+		})
+	})
+
+	await t.step("should enforce a single-element union of literal as key", async t => {
+		const Dict = Record(Union(Literal("a")), Number)
+		assertEquals(Dict.guard({}), false)
+		const error = assertThrows(() => Dict.check({}))
+		assertInstanceOf(error, ValidationError)
+		assertObjectMatch(error, {
+			failure: {
+				code: Failcode.CONTENT_INCORRECT,
+				details: {
+					a: {
+						code: Failcode.PROPERTY_MISSING,
+					},
+				},
+			},
+		})
+	})
+
 	await t.step("should work with certain edge case number keys", async t => {
 		const D = Record(Number, String)
 		type D = Static<typeof D>

--- a/src/Record.ts
+++ b/src/Record.ts
@@ -49,6 +49,15 @@ const extractLiteralKeys = (runtype: Runtype.Core<PropertyKey>) => {
 	const literalKeys: PropertyKey[] = []
 	const inner = unwrapTrivial(runtype as Runtype)
 	switch (inner.tag) {
+		case "literal": {
+			switch (typeof inner.value) {
+				case "string":
+				case "number":
+				case "symbol":
+					literalKeys.push(inner.value)
+			}
+			break
+		}
 		case "union": {
 			for (const alternative of inner.alternatives) {
 				const inner = unwrapTrivial(alternative as Runtype)


### PR DESCRIPTION
### Problem

A `Record` with a single literal key does not enforce that key as required:

```ts
import { Record, Literal, Number, Union } from "runtypes"

Record(Literal("a"), Number).guard({}) // => true  (should be false)
Record(Literal("a"), Number).check({}) // does not throw (should report PROPERTY_MISSING for "a")
```

The static type contract says the key is required:

```ts
type T = Static<Record<Literal<"a">, Number>> // { a: number }  ("a" is required)
```

A single-element union behaves the same way, because `unwrapTrivial` collapses it to one literal:

```ts
Record(Union(Literal("a")), Number).guard({}) // => true  (should be false)
```

A multi-literal union already enforces presence correctly, so the bare/collapsed case is an asymmetry:

```ts
Record(Union(Literal("a"), Literal("b")), Number).guard({}) // => false  (already correct)
```

### Cause

`extractLiteralKeys` builds the set of required keys, but it only walks a top-level `union`. A bare `Literal` key (or a single-element union that `unwrapTrivial` collapses to one literal) hits no branch, so no required key is collected and an empty object passes.

### Fix

Add a top-level `literal` case that mirrors the existing union-branch handling, pushing the literal value as a required key. This makes a bare or collapsed literal key enforce presence the same way a multi-literal union already does.

### Tests

Added two steps to `Record.test.ts` asserting that both a bare `Literal` key and a single-element `Union(Literal(...))` key reject `{}` with a `PROPERTY_MISSING` failure. Both fail on `master` and pass with this change; the existing union-of-literals enforcement test stays green.
